### PR TITLE
Fix stone oredicts

### DIFF
--- a/src/main/java/supersymmetry/loaders/SusyOreDictionaryLoader.java
+++ b/src/main/java/supersymmetry/loaders/SusyOreDictionaryLoader.java
@@ -1,16 +1,33 @@
 package supersymmetry.loaders;
 
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.common.blocks.MetaBlocks;
+import gregtech.common.blocks.StoneVariantBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
 import supersymmetry.common.blocks.SuSyBlocks;
 import supersymmetry.common.blocks.SusyStoneVariantBlock;
 
 
 public class SusyOreDictionaryLoader {
     public static void init(){
+        loadStoneOredict();
+    }
+
+    public static void loadStoneOredict(){
         for (SusyStoneVariantBlock.StoneType type : SusyStoneVariantBlock.StoneType.values()) {
-            ItemStack item = SuSyBlocks.SUSY_STONE_BLOCKS.get(SusyStoneVariantBlock.StoneVariant.SMOOTH).getItemVariant(type);
-            OreDictUnifier.registerOre(item, type.getOrePrefix(), type.getMaterial());
+            ItemStack smooth = SuSyBlocks.SUSY_STONE_BLOCKS.get(SusyStoneVariantBlock.StoneVariant.SMOOTH).getItemVariant(type);
+            ItemStack cobble = SuSyBlocks.SUSY_STONE_BLOCKS.get(SusyStoneVariantBlock.StoneVariant.COBBLE).getItemVariant(type);
+            OreDictUnifier.registerOre(smooth, type.getOrePrefix(), type.getMaterial());
+            OreDictionary.registerOre("stone", smooth);
+            OreDictionary.registerOre("cobblestone", cobble);
+        }
+
+        for (StoneVariantBlock.StoneType type : StoneVariantBlock.StoneType.values()) {
+            ItemStack smooth = MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getItemVariant(type);
+            ItemStack cobble = MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.COBBLE).getItemVariant(type);
+            OreDictionary.registerOre("stone", smooth);
+            OreDictionary.registerOre("cobblestone", cobble);
         }
     }
 }


### PR DESCRIPTION
## What
This PR moves some of the ore dict registration to susycore.

## Outcome
The susy and gt smooth and cobble variants of stone are now being oredicted to "stone" and "cobblestone", respectively. This fixes an issue with the supersymmetry server files, which prohibited people from launching a server.

## Additional Information
The oreDict.groovy file in the main project needs to be edited.