### PR TITLE
Fix various issues with coag tank and latex collector.

### DIFF
--- a/src/main/java/supersymmetry/Supersymmetry.java
+++ b/src/main/java/supersymmetry/Supersymmetry.java
@@ -36,6 +36,7 @@ public class Supersymmetry {
     @Mod.EventHandler
     public void onPreInit(@NotNull FMLPreInitializationEvent event) {
         proxy.preLoad();
+
         SuSyMetaItems.initMetaItems();
         SuSyBlocks.init();
 

--- a/src/main/java/supersymmetry/api/gui/SusyGuiTextures.java
+++ b/src/main/java/supersymmetry/api/gui/SusyGuiTextures.java
@@ -6,5 +6,4 @@ public class SusyGuiTextures {
     public static final SteamTexture PROGRESS_BAR_MIXER_STEAM = SteamTexture.fullImage("textures/gui/progress_bar/progress_bar_mixer_%s.png");
     public static final SteamTexture FLUID_SLOT_STEAM = SteamTexture.fullImage("textures/gui/base/fluid_slot_%s.png");
     public static final SteamTexture MOLD_OVERLAY_STEAM = SteamTexture.fullImage("textures/gui/overlay/mold_overlay_%s.png");
-
 }

--- a/src/main/java/supersymmetry/api/metatileentity/steam/SuSySteamProgressIndicators.java
+++ b/src/main/java/supersymmetry/api/metatileentity/steam/SuSySteamProgressIndicators.java
@@ -2,10 +2,13 @@ package supersymmetry.api.metatileentity.steam;
 
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.widgets.ProgressWidget;
+import supersymmetry.api.gui.SusyGuiTextures;
 
 public class SuSySteamProgressIndicators {
 
     public static final SuSySteamProgressIndicator COMPRESS = new SuSySteamProgressIndicator(GuiTextures.PROGRESS_BAR_COMPRESS_STEAM, ProgressWidget.MoveType.HORIZONTAL, 20, 15);
     public static final SuSySteamProgressIndicator ARROW = new SuSySteamProgressIndicator(GuiTextures.PROGRESS_BAR_ARROW_STEAM, ProgressWidget.MoveType.HORIZONTAL, 20, 15);
+    public static final SuSySteamProgressIndicator MIXER = new SuSySteamProgressIndicator(SusyGuiTextures.PROGRESS_BAR_MIXER_STEAM, ProgressWidget.MoveType.CIRCULAR, 20, 20);
+
 
 }

--- a/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
+++ b/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
@@ -21,7 +21,7 @@ public class SuSyRecipeMaps {
 
     public static final RecipeMap<PrimitiveRecipeBuilder> COAGULATION_RECIPES = new RecipeMap<>("coagulation_tank", 0, 2, 1, 1, 1, 2, 0, 0, new PrimitiveRecipeBuilder(), false);
 
-    public static final RecipeMap<SimpleRecipeBuilder> VULCANIZATION_RECIPES = new RecipeMap<>("vulcanizing_press", 1, 4, 1, 2, 0, 2, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> VULCANIZATION_RECIPES = new RecipeMap<>("vulcanizing_press", 4, 2, 2, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, true, GuiTextures.MOLD_OVERLAY)
             .setSound(GTSoundEvents.COMBUSTION);
 
@@ -43,16 +43,16 @@ public class SuSyRecipeMaps {
 
     public static final RecipeMap<SimpleRecipeBuilder> CRYSTALLIZER_RECIPES = new RecipeMap<>("crystallizer",1, 1, 1, 1, new SimpleRecipeBuilder(), false);
 
-    public static final RecipeMap<SimpleRecipeBuilder> BUBBLE_COLUMN_REACTOR_RECIPES = new RecipeMap<>("bubble_column_reactor", 0, 0, 3, 2, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> BUBBLE_COLUMN_REACTOR_RECIPES = new RecipeMap<>("bubble_column_reactor", 1, 0, 3, 2, new SimpleRecipeBuilder(), false)
             .setSound(GTSoundEvents.CHEMICAL_REACTOR);
 
     public static final RecipeMap<SimpleRecipeBuilder> DRYER = new RecipeMap<>("dryer", 1, 1, 1, 1, new SimpleRecipeBuilder(), false)
             .setSound(GTSoundEvents.CHEMICAL_REACTOR);
 
-    public static final RecipeMap<SimpleRecipeBuilder> FLUIDIZED_BED_REACTOR_RECIPES = new RecipeMap<>("fluidized_bed_reactor", 1, 0, 3, 2, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> FLUIDIZED_BED_REACTOR_RECIPES = new RecipeMap<>("fluidized_bed_reactor", 2, 1, 3, 2, new SimpleRecipeBuilder(), false)
             .setSound(GTSoundEvents.CHEMICAL_REACTOR);
 
-    public static final RecipeMap<SimpleRecipeBuilder> POLYMERIZATION_RECIPES = new RecipeMap<>("polymerization_tank", 1, 1, 2, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> POLYMERIZATION_RECIPES = new RecipeMap<>("polymerization_tank", 2, 1, 2, 1, new SimpleRecipeBuilder(), false)
             .setSound(GTSoundEvents.CHEMICAL_REACTOR);
 
 
@@ -60,5 +60,10 @@ public class SuSyRecipeMaps {
         RecipeMaps.SIFTER_RECIPES.setMaxFluidInputs(1);
         RecipeMaps.SIFTER_RECIPES.setMaxFluidOutputs(1);
         RecipeMaps.SIFTER_RECIPES.setMaxInputs(2);
+        RecipeMaps.CENTRIFUGE_RECIPES.setMaxFluidInputs(2);
+        RecipeMaps.CENTRIFUGE_RECIPES.setSlotOverlay(false, true, false, GuiTextures.CENTRIFUGE_OVERLAY);
+        RecipeMaps.MIXER_RECIPES.setMaxFluidInputs(3);
+        RecipeMaps.MIXER_RECIPES.setMaxFluidOutputs(2);
+        RecipeMaps.ARC_FURNACE_RECIPES.setMaxInputs(2);
     }
 }

--- a/src/main/java/supersymmetry/common/blocks/SuSyBlocks.java
+++ b/src/main/java/supersymmetry/common/blocks/SuSyBlocks.java
@@ -26,7 +26,6 @@ public class SuSyBlocks {
     public static BlockAlternatorCoil ALTERNATOR_COIL;
     public static BlockTurbineRotor TURBINE_ROTOR;
 
-
     public static void init() {
         COOLING_COIL = new BlockCoolingCoil();
         COOLING_COIL.setRegistryName("cooling_coil");

--- a/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
+++ b/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
@@ -82,7 +82,7 @@ public class SuSyMetaTileEntities {
         registerSimpleSteamMTE(STEAM_ROASTER, 14722, "roaster", SuSyRecipeMaps.ROASTER_RECIPES, SuSySteamProgressIndicators.ARROW, SusyTextures.ROASTER_OVERLAY, true);
         registerSimpleMTE(ROASTER, 12, 14523, "roaster", SuSyRecipeMaps.ROASTER_RECIPES, SusyTextures.ROASTER_OVERLAY, true);
 
-        registerSimpleSteamMTE(STEAM_MIXER, 14536, "mixer", RecipeMaps.MIXER_RECIPES, SuSySteamProgressIndicators.ARROW, SusyTextures.MIXER_OVERLAY_STEAM, false);
+        registerSimpleSteamMTE(STEAM_MIXER, 14536, "mixer", RecipeMaps.MIXER_RECIPES, SuSySteamProgressIndicators.MIXER, SusyTextures.MIXER_OVERLAY_STEAM, false);
 
         registerSimpleSteamMTE(STEAM_VACUUM_CHAMBER, 14538, "vacuum_chamber", SuSyRecipeMaps.VACUUM_CHAMBER, SuSySteamProgressIndicators.COMPRESS, Textures.GAS_COLLECTOR_OVERLAY, false);
         registerSimpleMTE(VACUUM_CHAMBER, 12, 14540, "vacuum_chamber", SuSyRecipeMaps.VACUUM_CHAMBER, Textures.GAS_COLLECTOR_OVERLAY, true);

--- a/src/main/java/supersymmetry/common/metatileentities/multi/primitive/MetaTileEntityCoagulationTank.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/primitive/MetaTileEntityCoagulationTank.java
@@ -110,12 +110,16 @@ public class MetaTileEntityCoagulationTank extends RecipeMapPrimitiveMultiblockC
 
     protected void formStructure(PatternMatchContext context) {
         super.formStructure(context);
-        this.initializeAbilities();
+        this.reinitializeAbilities();
     }
 
     @Override
     protected void initializeAbilities() {
         super.initializeAbilities();
+        this.reinitializeAbilities();
+    }
+
+    private void reinitializeAbilities() {
         this.outputInventory = new ItemHandlerList(this.getAbilities(MultiblockAbility.EXPORT_ITEMS));
         this.inputFluidInventory = new FluidTankList(false, this.getAbilities(MultiblockAbility.IMPORT_FLUIDS));
     }
@@ -124,6 +128,7 @@ public class MetaTileEntityCoagulationTank extends RecipeMapPrimitiveMultiblockC
     protected ICubeRenderer getFrontOverlay() {
         return Textures.PRIMITIVE_PUMP_OVERLAY;
     }
+    @Override
 
     public boolean hasMaintenanceMechanics() {
         return false;

--- a/src/main/java/supersymmetry/loaders/recipes/SuSyRecipeLoader.java
+++ b/src/main/java/supersymmetry/loaders/recipes/SuSyRecipeLoader.java
@@ -1,11 +1,11 @@
 package supersymmetry.loaders.recipes;
 
 import gregtech.api.recipes.ModHandler;
-import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.blocks.StoneVariantBlock;
 import net.minecraft.item.ItemStack;
+import supersymmetry.api.recipes.SuSyRecipeMaps;
 import supersymmetry.common.blocks.SuSyBlocks;
 import supersymmetry.common.blocks.SusyStoneVariantBlock;
 import supersymmetry.common.materials.SusyMaterials;

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -94,6 +94,7 @@ gregtech.machine.fluidized_bed_reactor.name=Fluidized Bed Reactor
 gregtech.recipe.plasma_requirement=Requires plasma: %s
 
 # Latex Collector
+gregtech.machine.latex_collector.steam=Needs Steam!
 gregtech.machine.latex_collector.tooltip=Collects latex from adjacent rubber tree log. Yields %d mL of latex per tick.
 gregtech.machine.latex_collector.bronze.name=Steam Latex Collector
 gregtech.machine.latex_collector.lv.name=Basic Latex Collector


### PR DESCRIPTION
## What
This aims to fix some issues with the latex collector and the coagulation tank.

## Implementation Details
The coagulation tank was resetting its inventory each time it formed the structure, which happens every time the world is loaded. This caused items and fluids to be yeeted from its inventory upon joining a world.

## Outcome
Latex collector and coagulation tank are now slightly less scuffed.

## Potential Compatibility Issues
May cause a merge conflict with [a different PR](https://github.com/SymmetricDevs/Susy-Core/pull/42), so you should let me merge those.
