### PR TITLE
Disable specific structure generation round 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ use_mixins=true
 use_coremod=true
 use_assetmover=false
 # Access Transformer files should be in the root of `resources` folder and with the filename formatted as: `{archives_base_name}_at.cfg`
-use_access_transformer=false
+use_access_transformer=true
 
 # Coremod Arguments
 include_mod = true

--- a/src/main/java/supersymmetry/common/worldgen/WorldgenControl.java
+++ b/src/main/java/supersymmetry/common/worldgen/WorldgenControl.java
@@ -1,0 +1,178 @@
+package supersymmetry.common.worldgen;
+
+import biomesoplenty.common.world.ChunkGeneratorHellBOP;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.*;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import rtg.api.world.gen.RTGChunkGenSettings;
+import rtg.world.gen.ChunkGeneratorRTG;
+import supersymmetry.Supersymmetry;
+import supersymmetry.api.SusyLog;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * Controls world generation
+ * <p>
+ * May require updates if BOP or RTG change field names or locations
+ */
+@Mod.EventBusSubscriber(modid = Supersymmetry.MODID) // cannot force server side here, doesn't work on SP
+public final class WorldgenControl {
+
+    private WorldgenControl() {/**/}
+
+    /**
+     * Disables structures
+     *
+     * @param event the event for World Loading
+     */
+    @SubscribeEvent
+    public static void disableStructures(@Nonnull WorldEvent.Load event) {
+        final World world = event.getWorld();
+        // must be server side
+        if (world.isRemote) return;
+
+        final IChunkProvider provider = world.getChunkProvider();
+        // this should be impossible, check anyway
+        if (!(provider instanceof ChunkProviderServer)) {
+            SusyLog.logger.fatal("Server-Side world in dimension {} did not have a ChunkProviderServer",
+                    world.provider.getDimensionType());
+            return;
+        }
+
+        // everything here should be guaranteed server-side only from now on
+
+        final IChunkGenerator generator = ((ChunkProviderServer) provider).chunkGenerator;
+
+        if (generator instanceof ChunkGeneratorOverworld) {
+            ChunkGeneratorSettings settings;
+            try {
+                Field field = ObfuscationReflectionHelper.findField(ChunkGeneratorOverworld.class, "settings");
+                field.setAccessible(true);
+                settings = (ChunkGeneratorSettings) field.get(generator);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("Failed to reflect ChunkGeneratorSettings in dim " + world.provider.getDimensionType(), e);
+            }
+
+            assert settings != null;
+            disableOverworldStructures(settings);
+        } else if (generator instanceof ChunkGeneratorHell) {
+            disableNetherStructures((ChunkGeneratorHell) generator);
+        } else if (generator instanceof ChunkGeneratorRTG) {
+            RTGChunkGenSettings settings;
+            try {
+                Field field = ObfuscationReflectionHelper.findField(ChunkGeneratorRTG.class, "settings");
+                field.setAccessible(true);
+                settings = (RTGChunkGenSettings) field.get(generator);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("Failed to reflect RTGChunkGenSettings in dim " + world.provider.getDimensionType(), e);
+            }
+
+            assert settings != null;
+            try {
+                disableRTGOverworldStructures(settings);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException("Failed to disable RTG structure gen in dim " + world.provider.getDimensionType(), e);
+            }
+        } else if (generator instanceof ChunkGeneratorHellBOP) {
+            try {
+                disableBOPNetherStructures((ChunkGeneratorHellBOP) generator);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException("Failed to disable BOP Nether structure gen in dim " + world.provider.getDimensionType(), e);
+            }
+        }
+    }
+
+    /**
+     * Disables vanilla overworld structures
+     *
+     * @param settings the chunk generator settings to disable it for
+     */
+    private static void disableOverworldStructures(@Nonnull ChunkGeneratorSettings settings) {
+        // villages
+        settings.useVillages = false;
+        // spawner dungeons
+        settings.useDungeons = false;
+        // jungle, desert temples, igloos, witch huts
+        settings.useTemples = false;
+        // ocean monuments
+        settings.useMonuments = false;
+        // woodland mansions
+        settings.useMansions = false;
+        // strongholds
+        settings.useStrongholds = false;
+    }
+
+    /**
+     * Disables RTG overworld structures
+     *
+     * @param settings the chunk generator settings to disable it for
+     * @throws NoSuchFieldException   if the field does not exist
+     * @throws IllegalAccessException if the field cannot be modified
+     */
+    private static void disableRTGOverworldStructures(@Nonnull RTGChunkGenSettings settings) throws NoSuchFieldException, IllegalAccessException {
+        // using getField because these fields are public
+
+        // villages
+        disableValue(settings, RTGChunkGenSettings.class.getField("useVillages"));
+        // spawner dungeons
+        disableValue(settings, RTGChunkGenSettings.class.getField("useDungeons"));
+        // jungle, desert temples, igloos, witch huts
+        disableValue(settings, RTGChunkGenSettings.class.getField("useTemples"));
+        // ocean monuments
+        disableValue(settings, RTGChunkGenSettings.class.getField("useMonuments"));
+        // woodland mansions
+        disableValue(settings, RTGChunkGenSettings.class.getField("useMansions"));
+        // strongholds
+        disableValue(settings, RTGChunkGenSettings.class.getField("useStrongholds"));
+    }
+
+    /**
+     * Disables nether structures
+     *
+     * @param generator the chunk generator to disable it for
+     */
+    private static void disableNetherStructures(@Nonnull ChunkGeneratorHell generator) {
+        generator.generateStructures = false;
+    }
+
+
+    /**
+     * Disables nether structures
+     *
+     * @param generator the chunk generator to disable it for
+     * @throws NoSuchFieldException   if the field does not exist
+     * @throws IllegalAccessException if the field cannot be modified
+     */
+    private static void disableBOPNetherStructures(@Nonnull ChunkGeneratorHellBOP generator) throws NoSuchFieldException, IllegalAccessException {
+        // needs declaredField because this is private in BOP
+        disableValue(generator, ChunkGeneratorHellBOP.class.getDeclaredField("generateStructures"));
+    }
+
+    /**
+     * Sets a final boolean to false
+     *
+     * @param o     the object to disable the field for
+     * @param field the field to disable
+     * @throws NoSuchFieldException   if the field does not exist
+     * @throws IllegalAccessException if the field cannot be modified
+     */
+    private static void disableValue(@Nonnull Object o, @Nonnull Field field) throws NoSuchFieldException, IllegalAccessException {
+        if (!field.isAccessible()) field.setAccessible(true);
+
+        if ((field.getModifiers() & Modifier.FINAL) != 0) {
+            // only make the field non-final if it's currently final
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        }
+
+        field.set(o, false);
+    }
+}

--- a/src/main/java/supersymmetry/common/worldgen/WorldgenControl.java
+++ b/src/main/java/supersymmetry/common/worldgen/WorldgenControl.java
@@ -50,7 +50,9 @@ public final class WorldgenControl {
         final IChunkGenerator generator = ((ChunkProviderServer) provider).chunkGenerator;
 
         if (generator instanceof ChunkGeneratorOverworld) {
-            disableOverworldStructures(((ChunkGeneratorOverworld) generator).settings);
+            ChunkGeneratorSettings settings = ((ChunkGeneratorOverworld) generator).settings;
+            // the settings are nullable, as they are not always initialized
+            if (settings != null) disableOverworldStructures(settings);
         } else if (generator instanceof ChunkGeneratorHell) {
             disableNetherStructures((ChunkGeneratorHell) generator);
         } else if (generator instanceof ChunkGeneratorRTG) {
@@ -130,7 +132,6 @@ public final class WorldgenControl {
     private static void disableNetherStructures(@Nonnull ChunkGeneratorHell generator) {
         generator.generateStructures = false;
     }
-
 
     /**
      * Disables nether structures

--- a/src/main/java/supersymmetry/common/worldgen/WorldgenControl.java
+++ b/src/main/java/supersymmetry/common/worldgen/WorldgenControl.java
@@ -6,7 +6,6 @@ import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.*;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import rtg.api.world.gen.RTGChunkGenSettings;
 import rtg.world.gen.ChunkGeneratorRTG;
@@ -51,26 +50,16 @@ public final class WorldgenControl {
         final IChunkGenerator generator = ((ChunkProviderServer) provider).chunkGenerator;
 
         if (generator instanceof ChunkGeneratorOverworld) {
-            ChunkGeneratorSettings settings;
-            try {
-                Field field = ObfuscationReflectionHelper.findField(ChunkGeneratorOverworld.class, "settings");
-                field.setAccessible(true);
-                settings = (ChunkGeneratorSettings) field.get(generator);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException("Failed to reflect ChunkGeneratorSettings in dim " + world.provider.getDimensionType(), e);
-            }
-
-            assert settings != null;
-            disableOverworldStructures(settings);
+            disableOverworldStructures(((ChunkGeneratorOverworld) generator).settings);
         } else if (generator instanceof ChunkGeneratorHell) {
             disableNetherStructures((ChunkGeneratorHell) generator);
         } else if (generator instanceof ChunkGeneratorRTG) {
             RTGChunkGenSettings settings;
             try {
-                Field field = ObfuscationReflectionHelper.findField(ChunkGeneratorRTG.class, "settings");
+                Field field = ChunkGeneratorRTG.class.getDeclaredField("settings");
                 field.setAccessible(true);
                 settings = (RTGChunkGenSettings) field.get(generator);
-            } catch (IllegalAccessException e) {
+            } catch (NoSuchFieldException | IllegalAccessException e) {
                 throw new RuntimeException("Failed to reflect RTGChunkGenSettings in dim " + world.provider.getDimensionType(), e);
             }
 

--- a/src/main/resources/supersymmetry_at.cfg
+++ b/src/main/resources/supersymmetry_at.cfg
@@ -1,0 +1,13 @@
+# ChunkGeneratorOverworld
+public net.minecraft.world.gen.ChunkGeneratorOverworld field_186000_s # settings
+
+# ChunkGeneratorHell
+public-f net.minecraft.world.gen.ChunkGeneratorHell field_185953_o # generateStructures
+
+# ChunkGeneratorSettings
+public-f net.minecraft.world.gen.ChunkGeneratorSettings field_177831_v # useVillages
+public-f net.minecraft.world.gen.ChunkGeneratorSettings field_177837_s # useDungeons
+public-f net.minecraft.world.gen.ChunkGeneratorSettings field_177854_x # useTemples
+public-f net.minecraft.world.gen.ChunkGeneratorSettings field_177852_y # useMonuments
+public-f net.minecraft.world.gen.ChunkGeneratorSettings field_191077_z # useMansions
+public-f net.minecraft.world.gen.ChunkGeneratorSettings field_177833_u # useStrongholds


### PR DESCRIPTION
This PR disables structure generation from other mods. Fixes issues caused by #45, by using AccessTransformers instead of Reflection for MC classes.

Has been tested in deobf/dev, but not in obf/production.
