### PR TITLE
Fix registerColors causing a crash on servers.

### DIFF
--- a/src/main/java/supersymmetry/client/ClientProxy.java
+++ b/src/main/java/supersymmetry/client/ClientProxy.java
@@ -37,6 +37,12 @@ public class ClientProxy extends CommonProxy {
         SusyMetaEntities.initRenderers();
     }
 
+    @Override
+    public void load() {
+        super.load();
+        SuSyMetaBlocks.registerColors();
+    }
+
     @SubscribeEvent
     public static void addMaterialFormulaHandler(@Nonnull ItemTooltipEvent event) {
         //ensure itemstack is a sheetedframe

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -41,7 +41,6 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
-        SuSyMetaBlocks.registerColors();
     }
 
     @SubscribeEvent


### PR DESCRIPTION
The registerColors is a clientside method, but it was called from CommonProxy. It has been moved to ClientProxy to prevent a crash on servers.