### PR TITLE
Add a nullcheck to fix an npe with dronepad.

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityDronePad.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityDronePad.java
@@ -224,7 +224,7 @@ public class MetaTileEntityDronePad extends RecipeMapMultiblockController {
                 this.parallelRecipesPerformed = 0;
                 this.overclockResults = new int[]{0, 0};
             }
-            this.getMetaTileEntity().drone.setDead();
+            if(this.getMetaTileEntity().drone != null) this.getMetaTileEntity().drone.setDead();
             this.getMetaTileEntity().droneReachedSky = false;
         }
     }


### PR DESCRIPTION
Probably needs some better logic for handling loading and unloading of the multiblock. In the meantime, we can just ignore the drone alltogether in the case that it gets unloaded during recipe handling, which is done in this PR.