### PR TITLE
Ambushes (for caballing Onslaught)

### DIFF
--- a/src/main/java/supersymmetry/api/event/MobHordeEvent.java
+++ b/src/main/java/supersymmetry/api/event/MobHordeEvent.java
@@ -1,0 +1,88 @@
+package supersymmetry.api.event;
+
+import gregtech.api.util.GTTeleporter;
+import gregtech.api.util.TeleportHandler;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementManager;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import supersymmetry.common.entities.EntityDropPod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class MobHordeEvent {
+    private Supplier<EntityLiving> entitySupplier;
+    private int quantityMin;
+    private int quantityMax;
+    private boolean nightOnly;
+    private ResourceLocation advancementUnlock;
+
+    public static final List<MobHordeEvent> EVENTS = new ArrayList<>();
+
+    public MobHordeEvent(Supplier<EntityLiving> entitySupplier, int quantityMin, int quantityMax) {
+        this.entitySupplier = entitySupplier;
+        this.quantityMin = quantityMin;
+        this.quantityMax = quantityMax;
+        this.EVENTS.add(this);
+    }
+
+    public MobHordeEvent setNightOnly(boolean nightOnly) {
+        this.nightOnly = nightOnly;
+        return this;
+    }
+
+    public MobHordeEvent setAdvancementUnlock(ResourceLocation advancementUnlock) {
+        this.advancementUnlock = advancementUnlock;
+        return this;
+    }
+
+    public void run(EntityPlayer player) {
+        int quantity = quantityMin + (int) (Math.random() * quantityMax);
+        for (int i = 0; i < quantity; i++) {
+            spawnMobWithPod(player);
+        }
+    }
+
+    public boolean canRun(EntityPlayerMP player) {
+        if (advancementUnlock != null) {
+            Advancement advancement = resourceLocationToAdvancement(advancementUnlock, player.world);
+            if (!player.getAdvancements().getProgress(advancement).isDone())
+                return false;
+        }
+        return !(player.world.isDaytime() && nightOnly);
+    }
+
+    private static Advancement resourceLocationToAdvancement(ResourceLocation location, World world) {
+        AdvancementManager advManager = ObfuscationReflectionHelper.getPrivateValue(World.class, world, "field_191951_C");
+        return advManager.getAdvancement(location);
+    }
+
+    public void spawnMobWithPod(EntityPlayer player) {
+        EntityDropPod pod = new EntityDropPod(player.world);
+        pod.rotationYaw = (float) Math.random() * 360;
+        EntityLiving mob = entitySupplier.get();
+
+        double x = player.posX + Math.random() * 60;
+        double y = 350 + Math.random() * 100;
+        double z = player.posZ + Math.random() * 60;
+
+        GTTeleporter teleporter = new GTTeleporter((WorldServer) player.world, x, y, z);
+        TeleportHandler.teleport(mob, player.dimension, teleporter, x, y, z);
+
+        mob.startRiding(pod, true);
+        mob.enablePersistence();
+
+        pod.setPosition(x, y, z);
+        player.world.spawnEntity(mob);
+        player.world.spawnEntity(pod);
+    }
+
+}

--- a/src/main/java/supersymmetry/api/event/MobHordeEvent.java
+++ b/src/main/java/supersymmetry/api/event/MobHordeEvent.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
@@ -16,18 +17,23 @@ import supersymmetry.common.entities.EntityDropPod;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class MobHordeEvent {
-    private Supplier<EntityLiving> entitySupplier;
+    private Function<EntityPlayer, EntityLiving> entitySupplier;
     private int quantityMin;
     private int quantityMax;
     private boolean nightOnly;
     private ResourceLocation advancementUnlock;
+    private int timerMin;
+    private int timerMax;
+    private int dimension = 0;
+    private int maximumDistanceUnderground = -1;
 
     public static final List<MobHordeEvent> EVENTS = new ArrayList<>();
 
-    public MobHordeEvent(Supplier<EntityLiving> entitySupplier, int quantityMin, int quantityMax) {
+    public MobHordeEvent(Function<EntityPlayer, EntityLiving> entitySupplier, int quantityMin, int quantityMax) {
         this.entitySupplier = entitySupplier;
         this.quantityMin = quantityMin;
         this.quantityMax = quantityMax;
@@ -57,6 +63,12 @@ public class MobHordeEvent {
             if (!player.getAdvancements().getProgress(advancement).isDone())
                 return false;
         }
+        if (player.dimension != this.dimension) {
+            return false;
+        }
+        if (maximumDistanceUnderground != -1 && !player.world.canBlockSeeSky(new BlockPos(player).up())) {
+            return false;
+        }
         return !(player.world.isDaytime() && nightOnly);
     }
 
@@ -68,21 +80,41 @@ public class MobHordeEvent {
     public void spawnMobWithPod(EntityPlayer player) {
         EntityDropPod pod = new EntityDropPod(player.world);
         pod.rotationYaw = (float) Math.random() * 360;
-        EntityLiving mob = entitySupplier.get();
+        EntityLiving mob = entitySupplier.apply(player);
 
         double x = player.posX + Math.random() * 60;
-        double y = 350 + Math.random() * 100;
+        double y = 350 + Math.random() * 200;
         double z = player.posZ + Math.random() * 60;
 
         GTTeleporter teleporter = new GTTeleporter((WorldServer) player.world, x, y, z);
         TeleportHandler.teleport(mob, player.dimension, teleporter, x, y, z);
 
+        pod.setPosition(x, y, z);
+        player.world.spawnEntity(pod);
+        player.world.spawnEntity(mob);
+
         mob.startRiding(pod, true);
         mob.enablePersistence();
 
-        pod.setPosition(x, y, z);
-        player.world.spawnEntity(mob);
-        player.world.spawnEntity(pod);
     }
 
+    public int getNextDelay() {
+        return timerMin + (int) (Math.random() * timerMax);
+    }
+
+    public MobHordeEvent setTimer(int min, int max) {
+        this.timerMin = min;
+        this.timerMax = max;
+        return this;
+    }
+
+    public MobHordeEvent setDimension(int dimension) {
+        this.dimension = dimension;
+        return this;
+    }
+
+    public MobHordeEvent setMaximumDistanceUnderground(int maximumDistanceUnderground) {
+        this.maximumDistanceUnderground = maximumDistanceUnderground;
+        return this;
+    }
 }

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -43,7 +43,7 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
-        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8);
+        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8).setMaximumDistanceUnderground(10);
     }
 
     @SubscribeEvent

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -4,6 +4,7 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.block.VariantItemBlock;
 import gregtech.common.items.MetaItems;
 import net.minecraft.block.Block;
+import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.crafting.IRecipe;
@@ -14,6 +15,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import supersymmetry.Supersymmetry;
+import supersymmetry.api.event.MobHordeEvent;
 import supersymmetry.api.recipes.SuSyRecipeMaps;
 import supersymmetry.api.unification.ore.SusyOrePrefix;
 import supersymmetry.api.unification.ore.SusyStoneTypes;
@@ -41,6 +43,7 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
+        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8);
     }
 
     @SubscribeEvent

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -43,7 +43,7 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
-        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8).setMaximumDistanceUnderground(10);
+        //new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8).setMaximumDistanceUnderground(10);
     }
 
     @SubscribeEvent

--- a/src/main/java/supersymmetry/common/EventHandlers.java
+++ b/src/main/java/supersymmetry/common/EventHandlers.java
@@ -8,7 +8,9 @@ import gregtech.common.items.MetaItems;
 import gregtechfoodoption.item.GTFOMetaItem;
 import net.minecraft.block.BlockCauldron;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,6 +18,7 @@ import net.minecraft.stats.StatList;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.event.entity.player.FillBucketEvent;
@@ -28,9 +31,15 @@ import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
 import supersymmetry.Supersymmetry;
 import supersymmetry.api.SusyLog;
+import supersymmetry.api.event.MobHordeEvent;
 import supersymmetry.common.entities.EntityDropPod;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Mod.EventBusSubscriber(modid = Supersymmetry.MODID)
 public class EventHandlers {
@@ -115,4 +124,12 @@ public class EventHandlers {
         event.setCanceled(true);
     }
 
+    @SubscribeEvent
+    public static void onServerTick(TickEvent.PlayerTickEvent event) {
+        if (!event.player.world.isRemote && event.player.world.provider.isSurfaceWorld() && !event.player.world.getDifficulty().equals(EnumDifficulty.PEACEFUL) && Math.random() < 0.01) {
+            List<MobHordeEvent> doableEvents = MobHordeEvent.EVENTS.stream().filter(e -> e.canRun((EntityPlayerMP) event.player)).toList();
+            if (!doableEvents.isEmpty())
+                doableEvents.get((int) (Math.random() * doableEvents.size())).run(event.player);
+        }
+    }
 }

--- a/src/main/java/supersymmetry/common/entities/EntityDropPod.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDropPod.java
@@ -232,6 +232,7 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
 
             if (!this.hasLanded()) {
                 this.handleCollidedBlocks();
+                this.getPassengers().forEach(e -> e.fallDistance = 0);
             }
 
             this.setLanded(this.hasLanded() || this.onGround);

--- a/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
+++ b/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
@@ -1,0 +1,61 @@
+package supersymmetry.common.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.util.INBTSerializable;
+import supersymmetry.api.event.MobHordeEvent;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
+    // Player cooldown for all events.
+    public int ticksUntilCanSpawn;
+    public int gracePeriod;
+    public int[] invasionTimers;
+
+    public MobHordePlayerData(int gracePeriod) {
+        this.ticksUntilCanSpawn = gracePeriod;
+        this.gracePeriod = gracePeriod;
+        this.invasionTimers = new int[MobHordeEvent.EVENTS.size()];
+    }
+
+    @Override
+    public NBTTagCompound serializeNBT() {
+        NBTTagCompound result = new NBTTagCompound();
+        result.setInteger("ticksUntilCanSpawn", ticksUntilCanSpawn);
+        result.setIntArray("invasionTimers", invasionTimers);
+        return result;
+    }
+
+    @Override
+    public void deserializeNBT(NBTTagCompound nbt) {
+        ticksUntilCanSpawn = nbt.getInteger("ticksUntilCanSpawn");
+        invasionTimers = nbt.getIntArray("invasionTimers");
+    }
+
+    public void update(EntityPlayerMP player) {
+        ticksUntilCanSpawn--;
+        for (int i = 0; i < invasionTimers.length; i++) {
+            invasionTimers[i]--;
+        }
+        if (ticksUntilCanSpawn <= 0 && Math.random() < 0.001) {
+            List<Integer> doableEvents = new ArrayList<>();
+            for (int i = 0; i < MobHordeEvent.EVENTS.size(); i++) {
+                MobHordeEvent event = MobHordeEvent.EVENTS.get(i);
+                if (event.canRun(player) && invasionTimers[i] <= 0) {
+                    doableEvents.add(i);
+                }
+            }
+            if (!doableEvents.isEmpty()) {
+                ticksUntilCanSpawn = gracePeriod;
+                int index = doableEvents.get((int) (Math.random() * doableEvents.size()));
+                MobHordeEvent event = MobHordeEvent.EVENTS.get(index);
+                event.run(player);
+                invasionTimers[index] = event.getNextDelay();
+            }
+        }
+    }
+}

--- a/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
+++ b/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
@@ -53,8 +53,9 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
                 ticksUntilCanSpawn = gracePeriod;
                 int index = doableEvents.get((int) (Math.random() * doableEvents.size()));
                 MobHordeEvent event = MobHordeEvent.EVENTS.get(index);
-                event.run(player);
-                invasionTimers[index] = event.getNextDelay();
+                if (event.run(player)) {
+                    invasionTimers[index] = event.getNextDelay();
+                }
             }
         }
     }

--- a/src/main/java/supersymmetry/common/event/MobHordeWorldData.java
+++ b/src/main/java/supersymmetry/common/event/MobHordeWorldData.java
@@ -1,0 +1,95 @@
+package supersymmetry.common.event;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.world.World;
+import net.minecraft.world.storage.MapStorage;
+import net.minecraft.world.storage.WorldSavedData;
+import net.minecraftforge.common.util.Constants;
+import supersymmetry.Supersymmetry;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class MobHordeWorldData extends WorldSavedData
+        implements Function<UUID, MobHordePlayerData> {
+
+    private static final String DATA_NAME = Supersymmetry.MODID + "_InvasionData";
+    private final Map<UUID, MobHordePlayerData> playerDataMap;
+
+    public MobHordeWorldData() {
+        this(DATA_NAME);
+    }
+
+    public MobHordeWorldData(String name) {
+        super(name);
+        this.playerDataMap = new HashMap<>();
+    }
+
+    public static MobHordeWorldData get(World world) {
+        MapStorage storage = world.getMapStorage();
+
+        if (storage == null) {
+            throw new RuntimeException("Null world storage");
+        }
+
+        MobHordeWorldData instance =
+                (MobHordeWorldData) storage.getOrLoadData(MobHordeWorldData.class, DATA_NAME);
+
+        if (instance == null) {
+            instance = new MobHordeWorldData();
+            storage.setData(DATA_NAME, instance);
+        }
+        return instance;
+    }
+
+    @Override
+    public MobHordePlayerData apply(UUID uuid) {
+        return this.getPlayerData(uuid);
+    }
+
+    public MobHordePlayerData getPlayerData(UUID uuid) {
+        MobHordePlayerData invasionPlayerData = this.playerDataMap.get(uuid);
+
+        if (invasionPlayerData == null) {
+            invasionPlayerData = new MobHordePlayerData(1000);
+            this.playerDataMap.put(uuid, invasionPlayerData);
+            this.markDirty();
+        }
+
+        return invasionPlayerData;
+    }
+
+    @Override
+    public void readFromNBT(@Nonnull NBTTagCompound tag) {
+        NBTTagList tagList = tag.getTagList("PlayerData", Constants.NBT.TAG_COMPOUND);
+
+        for (int i = 0; i < tagList.tagCount(); i++) {
+            NBTTagCompound tagEntry = (NBTTagCompound) tagList.get(i);
+            UUID uuid = UUID.fromString(tagEntry.getString("UUID"));
+            MobHordePlayerData data = new MobHordePlayerData(1000);
+            data.deserializeNBT(tagEntry.getCompoundTag("Data"));
+            this.playerDataMap.put(uuid, data);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound tag) {
+        NBTTagList tagList = new NBTTagList();
+
+        for (Map.Entry<UUID, MobHordePlayerData> entry : this.playerDataMap.entrySet()) {
+            NBTTagCompound tagEntry = new NBTTagCompound();
+            tagEntry.setString("UUID", entry.getKey().toString());
+            tagEntry.setTag("Data", entry.getValue().serializeNBT());
+            tagList.appendTag(tagEntry);
+        }
+
+        tag.setTag("PlayerData", tagList);
+
+        return tag;
+    }
+}


### PR DESCRIPTION
This allows for ambush events to be created within SuSyCore. Events are based on players, and can be modified in these ways:
- how entities are created through a supplier
- their minimum and maximum quantities per ambush
- if they only spawn during night
- which advancement they start on
- which dimension they spawn in
- how close to the surface a player has to be to spawn an invasion, if at all
- the minimum time between two events

Furthermore, as of now, this system also sets a minimum time between any two events for each player, currently set to 50 seconds for testing, although we should discuss what this value should actually be.