### PR TITLE
Custom Recipe Logic Added; Weird Server-Client De-Sync Obstructing Testing

### DIFF
--- a/src/main/java/supersymmetry/api/capability/impl/EvapRecipeLogic.java
+++ b/src/main/java/supersymmetry/api/capability/impl/EvapRecipeLogic.java
@@ -1,0 +1,109 @@
+package supersymmetry.api.capability.impl;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.impl.MultiblockRecipeLogic;
+
+import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.OverclockingLogic;
+import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
+import supersymmetry.common.metatileentities.multi.electric.MetaTileEntityEvaporationPool;
+
+import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
+import static supersymmetry.api.util.SuSyUtility.JOULES_PER_EU;
+
+public class EvapRecipeLogic extends MultiblockRecipeLogic {
+    private final MetaTileEntityEvaporationPool pool;
+    public static final int HEAT_DENOMINATOR = 6*20; //transfers one sixth of its energy every second (20 ticks)
+    public static final int MAX_STEP_FRACTION = 4; //denominator of fraction of progress which can be done in one step. (1/(MAX_STEP_FRACTION)) = max percent allowed
+
+    public EvapRecipeLogic(MetaTileEntityEvaporationPool tileEntity) {
+        super(tileEntity);
+        pool = tileEntity;
+    }
+
+    @Override
+    protected void updateRecipeProgress() {
+        //if null then no heating can be done, otherwise add joules according to coil values and energy available
+        if (pool.coilStats != null) {
+            int coilHeat = pool.coilStats.getCoilTemperature();
+            //assumes specific heat of 1J/(g*delta temp) and perfect heat transfer on one face of the coil for 1/6 of total delta temp. Uses mass as a multiplier and 1/4 because its not a solid block of material
+            int heatingJoules = (coilHeat/HEAT_DENOMINATOR) * ((int)pool.coilStats.getMaterial().getMass()/4) * ( ((pool.getColumnCount()/2 +1) * pool.getRowCount()) + pool.getColumnCount()/2);
+            heatingJoules = Math.min(((int)getEnergyStored()) * JOULES_PER_EU, heatingJoules);
+            pool.inputEnergy(heatingJoules);
+        }
+
+        int maxSteps = pool.calcMaxSteps(recipeEUt * JOULES_PER_EU);
+
+        if (this.canRecipeProgress && maxSteps > 0) {
+            hasNotEnoughEnergy = false;
+            int actualSteps =  Math.min(this.maxProgressTime >> 2, maxSteps);
+            progressTime += actualSteps;
+
+            int resultingEnergy;
+
+            //take energy from buffer first to avoid muddying kJ calculations
+            if (pool.getJoulesBuffer()/(recipeEUt * JOULES_PER_EU) > 0) {
+                resultingEnergy =  pool.getJoulesBuffer()/(recipeEUt * JOULES_PER_EU);
+                actualSteps -= resultingEnergy;
+                resultingEnergy = pool.getJoulesBuffer() - (resultingEnergy * (recipeEUt * JOULES_PER_EU));
+                pool.setJoulesBuffer(resultingEnergy);
+            }
+
+            resultingEnergy = pool.getKiloJoules() - (recipeEUt * JOULES_PER_EU * actualSteps)/1000 - (recipeEUt * JOULES_PER_EU * actualSteps % 1000 == 0 ? 0 : 1);
+            pool.setKiloJoules(resultingEnergy);
+
+            if (this.progressTime > this.maxProgressTime) completeRecipe();
+        } else {
+            this.hasNotEnoughEnergy = true;
+            //only decrease progress once a tick when using max sized pool
+            if (pool.getOffsetTimer() % (pool.MAX_COLUMNS * pool.MAX_COLUMNS)/(pool.getColumnCount() * pool.getRowCount()) == 0L) this.decreaseProgress();
+        }
+    }
+
+    //copied from NoEnergyMultiblockRecipeLogic and modified to allow energy and no energy
+    @Override
+    protected long getEnergyInputPerSecond() {
+        return super.getEnergyInputPerSecond() == 0? 2147483647L : super.getEnergyInputPerSecond();
+    }
+
+    @Override
+    protected long getEnergyStored() {
+        return Math.max(0L, super.getEnergyStored());
+    }
+
+    @Override
+    protected long getEnergyCapacity() {
+        return super.getEnergyCapacity() == 0 ? 2147483647L : super.getEnergyCapacity();
+    }
+
+    @Override
+    protected boolean drawEnergy(int recipeEUt, boolean simulate) { return true; }
+
+    @Override
+    protected long getMaxVoltage() {
+        return Math.max(1L, super.getMaxVoltage());
+    }
+
+    @Override
+    protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
+        return OverclockingLogic.standardOverclockingLogic(recipeEUt, this.getMaxVoltage(), recipeDuration, amountOC, this.getOverclockingDurationDivisor(), this.getOverclockingVoltageMultiplier());
+    }
+
+    @Override
+    public long getMaximumOverclockVoltage() {
+        return getEnergyCapacity() == 0? GTValues.V[1] : super.getMaximumOverclockVoltage();
+    }
+
+    public void invalidate() {
+        this.previousRecipe = null;
+        this.progressTime = 0;
+        this.maxProgressTime = 0;
+        this.recipeEUt = 0;
+        this.fluidOutputs = null;
+        this.itemOutputs = null;
+        this.setActive(false);
+    }
+}

--- a/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
+++ b/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
@@ -379,7 +379,7 @@ public class SuSyRecipeMaps {
 
         SuSyRecipeMaps.EVAPORATION_POOL.recipeBuilder()
                 .fluidInputs(Materials.Water.getFluid(10000))
-                .EUt(30)
+                .EUt(30) //300J/t -> 6kJ/s -> 6 exposed blocks
                 .duration(200)
                 .buildAndRegister();
     }

--- a/src/main/java/supersymmetry/api/util/SuSyUtility.java
+++ b/src/main/java/supersymmetry/api/util/SuSyUtility.java
@@ -7,6 +7,15 @@ import supersymmetry.Supersymmetry;
 import java.util.function.Function;
 
 public class SuSyUtility {
+
+    /*
+        if we assume a solar boiler to have an approximately 1m^2 "collecting" surface, and take the hp to be less inefficient,
+        one can approximate the J to EU conversion via 18L/t -> 9EU/t -> 180EU/s -> 1000J/180EU ~= 6J in one EU.
+        Assuming solar actually gets slightly less sunlight than 1m^2 conversion may be ~= 5, but potential inefficiencies
+        make it unclear the specific amount. Just going to round to one sig fig and leave it at 10J -> 1EU
+    */
+    public static final int JOULES_PER_EU = 10;
+
     public static final Function<Integer, Integer> reactorTankSizeFunction = tier -> {
         if (tier <= GTValues.LV)
             return 12000;

--- a/src/main/java/supersymmetry/common/materials/SusyMaterials.java
+++ b/src/main/java/supersymmetry/common/materials/SusyMaterials.java
@@ -62,7 +62,6 @@ public class SusyMaterials {
 
     private static void changeProperties() {
         //removeProperty(PropertyKey.ORE, Materials.Graphite);
-
         Latex.getProperty(PropertyKey.FLUID).setFluidTemperature(293);
         removeProperty(PropertyKey.ORE, Materials.Soapstone);
         removeProperty(PropertyKey.ORE, Materials.Quartzite);
@@ -123,16 +122,6 @@ public class SusyMaterials {
 
         Materials.Salt.setProperty(PropertyKey.FLUID, new FluidProperty());
 
-        Materials.SodiumHydroxide.setProperty(PropertyKey.FLUID, new FluidProperty());
-
-        Materials.Sodium.setProperty(PropertyKey.FLUID, new FluidProperty());
-
-        Materials.Phosphorus.setFormula("P4", true);
-        Materials.Phosphorus.setProperty(PropertyKey.INGOT, new IngotProperty());
-        Materials.Phosphorus.setProperty(PropertyKey.FLUID, new FluidProperty());
-        Materials.Phosphorus.getProperty(PropertyKey.FLUID).setFluidTemperature(317);
-        Materials.Phosphorus.setMaterialRGB(0xfffed6);
-
         Materials.HydrochloricAcid.setFormula("(H2O)(HCl)", true);
 
         Materials.HydrofluoricAcid.setFormula("(H2O)(HF)", true);
@@ -165,8 +154,6 @@ public class SusyMaterials {
         Materials.Rhodium.addFlags(SuSyMaterialFlags.GENERATE_CATALYST_BED);
 
         Materials.Copper.addFlags(SuSyMaterialFlags.GENERATE_CATALYST_BED);
-
-        Materials.Electrum.setProperty(PropertyKey.ORE, new OreProperty());
     }
 
     private static void removeProperty(PropertyKey<?> key, Material material) {

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -224,7 +224,7 @@ gregtech.machine.railroad_engineering_station.name=Railroad Engineering Station
 gregtech.machine.railroad_engineering_station.tooltip=Place Immersive Railroading Tracks in the middle to form the multiblock\nThe concrete below the tracks can be substituted with any block, including pipes or air
 
 gregtech.machine.evaporation_pool.name=Evaporation Pool
-gregtech.machine.evaporation_pool.tooltip.structure_info=Evaporation Pools can be formed with any internal dimensions ranging from a 1x1 to a %dx%d, even if it is non square. To form a valid heated evaporation pool, coils should be placed following the pattern shown in the preview.
+gregtech.machine.evaporation_pool.tooltip.structure_info=Evaporation Pools can be formed with any internal dimensions ranging from a 1x1 to a %dx%d, even if it is non square. To form a valid heated evaporation pool, coils should be placed following the pattern shown in the preview. For a more detailed explanation, view the info tab in jei.
 gregtech.top.evaporation_pool_heated_preface=Coil Pattern:
 gregtech.top.evaporation_pool_is_heated=VALID; May be heated.
 gregtech.top.evaporation_pool_not_heated=INVALID; Will not heat.


### PR DESCRIPTION
Weird de-sync between the server and client when attempting to see if a block has skylight access, alongside the same issue with relogging invalidating valid structures and the supposed structure error not making any sense, nor being fixed with block replacement. Needs further testing from other people.