### PR TITLE
Invasion Commands

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     compileOnly rfg.deobf('curse.maven:biomes-o-plenty-220318:2842510')
 
-    implementation rfg.deobf('curse.maven:gregtech-food-option-477021:4904513') // GT-FO 1.10.2
+    implementation rfg.deobf('curse.maven:gregtech-food-option-477021:5085993') // GT-FO 1.10.2
 
     implementation rfg.deobf('curse.maven:applecore-224472:2969118')
 

--- a/src/main/java/supersymmetry/Supersymmetry.java
+++ b/src/main/java/supersymmetry/Supersymmetry.java
@@ -6,12 +6,15 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLConstructionEvent;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import org.jetbrains.annotations.NotNull;
 import supersymmetry.api.sound.SusySounds;
 import supersymmetry.common.CommonProxy;
 import supersymmetry.common.SusyMetaEntities;
 import supersymmetry.common.blocks.SuSyBlocks;
 import supersymmetry.common.blocks.SuSyMetaBlocks;
+import supersymmetry.common.command.CommandHordeBase;
+import supersymmetry.common.command.CommandHordeStart;
 import supersymmetry.common.covers.SuSyCoverBehaviors;
 import supersymmetry.common.item.SuSyMetaItems;
 import supersymmetry.common.metatileentities.SuSyMetaTileEntities;
@@ -53,5 +56,14 @@ public class Supersymmetry {
     public void onInit(@NotNull FMLInitializationEvent event) {
         proxy.load();
         SuSyCoverBehaviors.init();
+    }
+
+    @Mod.EventHandler
+    public void onServerStarting(@NotNull FMLServerStartingEvent event) {
+        CommandHordeBase hordeCommand = new CommandHordeBase();
+        event.registerServerCommand(hordeCommand);
+
+        hordeCommand.addSubcommand(new CommandHordeStart());
+
     }
 }

--- a/src/main/java/supersymmetry/Supersymmetry.java
+++ b/src/main/java/supersymmetry/Supersymmetry.java
@@ -15,6 +15,7 @@ import supersymmetry.common.blocks.SuSyBlocks;
 import supersymmetry.common.blocks.SuSyMetaBlocks;
 import supersymmetry.common.command.CommandHordeBase;
 import supersymmetry.common.command.CommandHordeStart;
+import supersymmetry.common.command.CommandHordeStop;
 import supersymmetry.common.covers.SuSyCoverBehaviors;
 import supersymmetry.common.item.SuSyMetaItems;
 import supersymmetry.common.metatileentities.SuSyMetaTileEntities;
@@ -64,6 +65,7 @@ public class Supersymmetry {
         event.registerServerCommand(hordeCommand);
 
         hordeCommand.addSubcommand(new CommandHordeStart());
+        hordeCommand.addSubcommand(new CommandHordeStop());
 
     }
 }

--- a/src/main/java/supersymmetry/api/event/MobHordeEvent.java
+++ b/src/main/java/supersymmetry/api/event/MobHordeEvent.java
@@ -127,7 +127,7 @@ public class MobHordeEvent {
             int z = (int) (player.posZ + 15 * Math.sin(angle));
 
             mob.setPosition(x, player.posY - 5, z);
-            while (!mob.getCanSpawnHere() || !mob.isNotColliding() && mob.posY < player.posY + 12) {
+            while ((!mob.getCanSpawnHere() || !mob.isNotColliding()) && mob.posY < player.posY + 12) {
                 mob.setPosition(x, mob.posY + 1, z);
             }
             if (mob.posY < player.posY + 12) {

--- a/src/main/java/supersymmetry/api/event/MobHordeEvent.java
+++ b/src/main/java/supersymmetry/api/event/MobHordeEvent.java
@@ -141,7 +141,7 @@ public class MobHordeEvent {
     }
 
     public int getNextDelay() {
-        return timerMin + (int) (Math.random() * timerMax);
+        return timerMin + (int) (Math.random() * (double) (timerMax - timerMin));
     }
 
     public MobHordeEvent setTimer(int min, int max) {

--- a/src/main/java/supersymmetry/api/event/MobHordeEvent.java
+++ b/src/main/java/supersymmetry/api/event/MobHordeEvent.java
@@ -6,7 +6,6 @@ import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementManager;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.IEntityLivingData;
-import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
@@ -16,10 +15,9 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import supersymmetry.common.entities.EntityDropPod;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public class MobHordeEvent {
     private Function<EntityPlayer, EntityLiving> entitySupplier;
@@ -32,14 +30,16 @@ public class MobHordeEvent {
     private int dimension = 0;
     private int maximumDistanceUnderground = -1;
     private boolean canUsePods = true;
+    private String KEY;
 
-    public static final List<MobHordeEvent> EVENTS = new ArrayList<>();
+    public static final Map<String, MobHordeEvent> EVENTS = new HashMap<>();
 
-    public MobHordeEvent(Function<EntityPlayer, EntityLiving> entitySupplier, int quantityMin, int quantityMax) {
+    public MobHordeEvent(Function<EntityPlayer, EntityLiving> entitySupplier, int quantityMin, int quantityMax, String name) {
         this.entitySupplier = entitySupplier;
         this.quantityMin = quantityMin;
         this.quantityMax = quantityMax;
-        this.EVENTS.add(this);
+        this.KEY = name;
+        this.EVENTS.put(name, this);
     }
 
     public MobHordeEvent setNightOnly(boolean nightOnly) {

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -1,7 +1,8 @@
 package supersymmetry.common;
 
-import gregtech.api.GregTechAPI;
 import gregtech.api.block.VariantItemBlock;
+import gregtech.api.unification.material.event.MaterialEvent;
+import gregtech.api.unification.material.event.PostMaterialEvent;
 import gregtech.common.items.MetaItems;
 import net.minecraft.block.Block;
 import net.minecraft.entity.monster.EntityZombie;
@@ -19,16 +20,15 @@ import supersymmetry.api.event.MobHordeEvent;
 import supersymmetry.api.recipes.SuSyRecipeMaps;
 import supersymmetry.api.unification.ore.SusyOrePrefix;
 import supersymmetry.api.unification.ore.SusyStoneTypes;
-import supersymmetry.api.unification.material.properties.SuSyPropertyKey;
-import supersymmetry.common.blocks.*;
+import supersymmetry.common.blocks.SheetedFrameItemBlock;
+import supersymmetry.common.blocks.SuSyBlocks;
+import supersymmetry.common.blocks.SuSyMetaBlocks;
+import supersymmetry.common.blocks.SusyStoneVariantBlock;
 import supersymmetry.common.item.SuSyMetaItems;
 import supersymmetry.common.materials.SusyMaterials;
 import supersymmetry.loaders.SuSyWorldLoader;
-import supersymmetry.loaders.recipes.SuSyRecipeLoader;
 import supersymmetry.loaders.SusyOreDictionaryLoader;
-import supersymmetry.loaders.recipes.SuSyMaterialRecipeHandler;
-import gregtech.api.unification.material.event.MaterialEvent;
-import gregtech.api.unification.material.event.PostMaterialEvent;
+import supersymmetry.loaders.recipes.SuSyRecipeLoader;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -45,7 +45,7 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
-        //new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8).setMaximumDistanceUnderground(10);
+        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8, "zombies").setMaximumDistanceUnderground(10);
     }
 
     @SubscribeEvent

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -45,7 +45,7 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
-        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8, "zombies").setMaximumDistanceUnderground(10);
+        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8, "zombies").setMaximumDistanceUnderground(10).setNightOnly(true);
     }
 
     @SubscribeEvent

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -45,7 +45,7 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
-        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8, "zombies").setMaximumDistanceUnderground(10).setNightOnly(true);
+        //new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8, "zombies").setMaximumDistanceUnderground(10).setNightOnly(true);
     }
 
     @SubscribeEvent

--- a/src/main/java/supersymmetry/common/command/CommandHordeBase.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeBase.java
@@ -1,0 +1,37 @@
+package supersymmetry.common.command;
+
+import com.google.common.collect.Lists;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.server.command.CommandTreeBase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class CommandHordeBase extends CommandTreeBase {
+    @NotNull
+    @Override
+    public String getName() {
+        return "mobHorde";
+    }
+
+    @NotNull
+    @Override
+    public List<String> getAliases() {
+        return Lists.newArrayList("horde", "invasion");
+    }
+
+    @NotNull
+    @Override
+    public String getUsage(@NotNull ICommandSender sender) {
+        return "susy.command.horde.usage";
+    }
+
+    @Override
+    public void execute(@NotNull MinecraftServer server, @NotNull ICommandSender sender,
+                        String[] args) throws CommandException {
+        super.execute(server, sender, args);
+    }
+
+}

--- a/src/main/java/supersymmetry/common/command/CommandHordeBase.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeBase.java
@@ -34,4 +34,8 @@ public class CommandHordeBase extends CommandTreeBase {
         super.execute(server, sender, args);
     }
 
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 2;
+    }
 }

--- a/src/main/java/supersymmetry/common/command/CommandHordeStart.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeStart.java
@@ -73,6 +73,8 @@ public class CommandHordeStart extends CommandBase {
                 playerData.setCurrentInvasion(event);
                 ITextComponent textComponent = new TextComponentTranslation("susy.command.horde.start.started", event.KEY);
                 sender.sendMessage(textComponent);
+            } else {
+                throw new CommandException("susy.command.horde.start.argument_required");
             }
         }
     }

--- a/src/main/java/supersymmetry/common/command/CommandHordeStart.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeStart.java
@@ -1,0 +1,57 @@
+package supersymmetry.common.command;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import supersymmetry.api.event.MobHordeEvent;
+
+import java.util.List;
+
+public class CommandHordeStart extends CommandBase {
+
+    @NotNull
+    @Override
+    public String getName() {
+        return "start";
+    }
+
+    @NotNull
+    @Override
+    public String getUsage(@NotNull ICommandSender sender) {
+        return "susy.command.horde.start.usage";
+    }
+
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
+        return super.getTabCompletions(server, sender, args, targetPos);
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if(sender instanceof EntityPlayerMP) {
+            EntityPlayerMP player = (EntityPlayerMP) sender;
+            if (args.length > 0) {
+                String name = args[0];
+                MobHordeEvent event = MobHordeEvent.EVENTS.get(name);
+
+                if(event == null) {
+                    throw new CommandException("susy.command.horde.start.no_such_horde", name);
+                }
+
+                if(!event.canRun(player)) {
+                    throw new CommandException("susy.command.horde.start.unable_to_run");
+                }
+
+                if(!event.run(player)) {
+                    throw new CommandException("susy.command.horde.start.error_executing_horde");
+                }
+
+            }
+        }
+    }
+}

--- a/src/main/java/supersymmetry/common/command/CommandHordeStart.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeStart.java
@@ -52,7 +52,7 @@ public class CommandHordeStart extends CommandBase {
                 }
 
                 if (!event.canRun(player)) {
-                    throw new CommandException("susy.command.horde.start.unable_to_run");
+                    throw new CommandException("susy.command.horde.start.unable_to_run", name);
                 }
 
                 if (playerData.hasActiveInvasion) {

--- a/src/main/java/supersymmetry/common/command/CommandHordeStart.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeStart.java
@@ -57,7 +57,7 @@ public class CommandHordeStart extends CommandBase {
 
                 if (playerData.hasActiveInvasion) {
                     // true => overwrite existing invasion
-                    if (args.length > 1 && args[1] == "true") {
+                    if (args.length > 1 && args[1].equals("true")) {
                         playerData.stopInvasion(player);
                     } else {
                         ITextComponent textComponent = new TextComponentTranslation("susy.command.horde.start.has_active_invasion", playerData.currentInvasion);

--- a/src/main/java/supersymmetry/common/command/CommandHordeStop.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeStop.java
@@ -1,0 +1,4 @@
+package supersymmetry.common.command;
+
+public class CommandHordeStop {
+}

--- a/src/main/java/supersymmetry/common/command/CommandHordeStop.java
+++ b/src/main/java/supersymmetry/common/command/CommandHordeStop.java
@@ -1,4 +1,52 @@
 package supersymmetry.common.command;
 
-public class CommandHordeStop {
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentTranslation;
+import org.jetbrains.annotations.NotNull;
+import supersymmetry.common.event.MobHordePlayerData;
+import supersymmetry.common.event.MobHordeWorldData;
+
+
+public class CommandHordeStop extends CommandBase {
+
+    @NotNull
+    @Override
+    public String getName() {
+        return "stop";
+    }
+
+    @NotNull
+    @Override
+    public String getUsage(@NotNull ICommandSender sender) {
+        return "susy.command.horde.stop.usage";
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if(sender instanceof EntityPlayerMP) {
+            EntityPlayerMP player = (EntityPlayerMP) sender;
+
+            MobHordePlayerData playerData = MobHordeWorldData.get(player.world)
+                    .getPlayerData(player.getPersistentID());
+
+            if(!playerData.hasActiveInvasion) {
+                ITextComponent textComponent = new TextComponentTranslation("susy.command.horde.stop.has_active_no_invasion");
+                sender.sendMessage(textComponent);
+                return;
+            }
+
+            String invasion = playerData.currentInvasion;
+
+            playerData.stopInvasion(player);
+
+            ITextComponent textComponent = new TextComponentTranslation("susy.command.horde.stop.stopped", invasion);
+            sender.sendMessage(textComponent);
+        }
+    }
+
 }

--- a/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
+++ b/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
@@ -1,10 +1,15 @@
 package supersymmetry.common.event;
 
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import supersymmetry.api.event.MobHordeEvent;
 
 import java.util.*;
@@ -15,6 +20,9 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
     public int ticksUntilCanSpawn;
     public int gracePeriod;
     public int[] invasionTimers;
+    public boolean hasActiveInvasion = false;
+    public List<UUID> invasionEntitiesUUIDs = new ArrayList<>();
+    public String currentInvasion = "";
 
     public MobHordePlayerData(int gracePeriod) {
         this.ticksUntilCanSpawn = gracePeriod;
@@ -27,6 +35,14 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
         NBTTagCompound result = new NBTTagCompound();
         result.setInteger("ticksUntilCanSpawn", ticksUntilCanSpawn);
         result.setIntArray("invasionTimers", invasionTimers);
+        result.setBoolean("hasActiveInvasion", hasActiveInvasion);
+        if(this.hasActiveInvasion && !this.invasionEntitiesUUIDs.isEmpty()) {
+            result.setString("currentInvasion", currentInvasion);
+            NBTTagList tagList = new NBTTagList();
+            invasionEntitiesUUIDs.stream()
+                    .forEach(uuid -> tagList.appendTag(NBTUtil.createUUIDTag(uuid)));
+            result.setTag("invasionEntitiesUUIDs", tagList);
+        }
         return result;
     }
 
@@ -34,17 +50,26 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
     public void deserializeNBT(NBTTagCompound nbt) {
         ticksUntilCanSpawn = nbt.getInteger("ticksUntilCanSpawn");
         invasionTimers = Arrays.copyOf(nbt.getIntArray("invasionTimers"), MobHordeEvent.EVENTS.size());
+        hasActiveInvasion = nbt.getBoolean("hasActiveInvasion");
+        if (hasActiveInvasion) {
+            invasionEntitiesUUIDs.clear();
+            this.currentInvasion = nbt.getString("currentInvasion");
+            NBTTagList tagList = nbt.getTagList("invasionEntitiesUUIDs", Constants.NBT.TAG_COMPOUND);
+            tagList.forEach(compound -> invasionEntitiesUUIDs.add(NBTUtil.getUUIDFromTag((NBTTagCompound) compound)));
+        }
     }
 
     public void update(EntityPlayerMP player) {
+        if (hasActiveInvasion) return;
         ticksUntilCanSpawn--;
         for (int i = 0; i < invasionTimers.length; i++) {
             invasionTimers[i]--;
         }
         if (ticksUntilCanSpawn <= 0 && Math.random() < 0.001) {
             List<Integer> doableEvents = new ArrayList<>();
-            for (int i = 0; i < MobHordeEvent.EVENTS.size(); i++) {
-                MobHordeEvent event = MobHordeEvent.EVENTS.get(i);
+            for (int i = 0; i < MobHordeEvent.EVENTS.values().size(); i++) {
+                MobHordeEvent event = MobHordeEvent.EVENTS.values().stream()
+                        .collect(Collectors.toList()).get(i);
                 if (event.canRun(player) && invasionTimers[i] <= 0) {
                     doableEvents.add(i);
                 }
@@ -52,11 +77,59 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
             if (!doableEvents.isEmpty()) {
                 ticksUntilCanSpawn = gracePeriod;
                 int index = doableEvents.get((int) (Math.random() * doableEvents.size()));
-                MobHordeEvent event = MobHordeEvent.EVENTS.get(index);
-                if (event.run(player)) {
+                MobHordeEvent event = MobHordeEvent.EVENTS.values().stream()
+                        .collect(Collectors.toList()).get(index);
+                if (event.run(player, this::addEntity)) {
                     invasionTimers[index] = event.getNextDelay();
+
                 }
             }
+        }
+    }
+
+    @SubscribeEvent
+    public void onEntityDeath(LivingDeathEvent event) {
+        EntityLivingBase deadEntity = event.getEntityLiving();
+        UUID deadEntityUUID = deadEntity.getPersistentID();
+
+        if (invasionEntitiesUUIDs.contains(deadEntityUUID)) {
+            removeDeadEntity(deadEntityUUID);
+
+            // Check if all spawned entities are dead
+            if (invasionEntitiesUUIDs.isEmpty()) {
+                this.finishInvasion();
+            }
+        }
+    }
+
+    public void setCurrentInvasion(MobHordeEvent event) {
+        this.currentInvasion = event.KEY;
+        this.hasActiveInvasion = true;
+    }
+
+    public void addEntity(UUID uuid) {
+        this.invasionEntitiesUUIDs.add(uuid);
+    }
+
+    private void removeDeadEntity(UUID deadEntityUUID) {
+        this.invasionEntitiesUUIDs.remove(deadEntityUUID);
+    }
+
+    public void finishInvasion() {
+        this.hasActiveInvasion = false;
+        this.currentInvasion = "";
+
+    }
+
+    public void stopInvasion(EntityPlayerMP player) {
+        if(this.hasActiveInvasion) {
+            WorldServer world = player.getServerWorld();
+            this.invasionEntitiesUUIDs.stream()
+                    .map(uuid -> world.getEntityFromUuid(uuid))
+                    .filter(Objects::nonNull)
+                    .forEach(entity -> entity.setDead());
+            // Will get called implicitly from onEntityDeath, but I am doing it again just to be sure
+            this.finishInvasion();
         }
     }
 }

--- a/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
+++ b/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
@@ -67,9 +67,11 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
         }
         if (ticksUntilCanSpawn <= 0 && Math.random() < 0.001) {
             List<Integer> doableEvents = new ArrayList<>();
+            List<MobHordeEvent> events = MobHordeEvent.EVENTS.values().stream()
+                    .collect(Collectors.toList());
+            MobHordeEvent event;
             for (int i = 0; i < MobHordeEvent.EVENTS.values().size(); i++) {
-                MobHordeEvent event = MobHordeEvent.EVENTS.values().stream()
-                        .collect(Collectors.toList()).get(i);
+                event = events.get(i);
                 if (event.canRun(player) && invasionTimers[i] <= 0) {
                     doableEvents.add(i);
                 }
@@ -77,8 +79,7 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
             if (!doableEvents.isEmpty()) {
                 ticksUntilCanSpawn = gracePeriod;
                 int index = doableEvents.get((int) (Math.random() * doableEvents.size()));
-                MobHordeEvent event = MobHordeEvent.EVENTS.values().stream()
-                        .collect(Collectors.toList()).get(index);
+                event = events.get(index);
                 if (event.run(player, this::addEntity)) {
                     invasionTimers[index] = event.getNextDelay();
                     this.setCurrentInvasion(event);

--- a/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
+++ b/src/main/java/supersymmetry/common/event/MobHordePlayerData.java
@@ -81,7 +81,7 @@ public class MobHordePlayerData implements INBTSerializable<NBTTagCompound> {
                         .collect(Collectors.toList()).get(index);
                 if (event.run(player, this::addEntity)) {
                     invasionTimers[index] = event.getNextDelay();
-
+                    this.setCurrentInvasion(event);
                 }
             }
         }

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -747,9 +747,13 @@ susy.recipe.dimensions=Dimensions: %s
 
 # Commands
 
-susy.command.horde.usage=Usage: /mobHorde <start/stop>
-susy.command.horde.start.usage=Usage: /mobHorde start <name>
+susy.command.horde.usage=/mobHorde <start/stop>
+susy.command.horde.start.usage=/mobHorde start <name>
 susy.command.horde.start.no_such_horde=No such horde %s exists.
-
-
-
+susy.command.horde.start.unable_to_run=The %s horde can't be executed. This may be due to dimensional restrictions, daylight,...
+susy.command.horde.start.error_executing_horde=Horde mobs were not spawned correctly.
+susy.command.horde.start.has_active_invasion=You already have an active %s invasion.
+susy.command.horde.start.started=Successfully started %s invasion.
+susy.command.horde.stop.usage=/mobHorde stop
+susy.command.horde.stop.has_active_no_invasion=No active invasion to stop.
+susy.command.horde.stop.stopped=Successfully stopped %s invasion.

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -744,3 +744,12 @@ gregtech.block_group_members.latex_logs.name=Rubber Log
 
 # Extra recipe info
 susy.recipe.dimensions=Dimensions: %s
+
+# Commands
+
+susy.command.horde.usage=Usage: /mobHorde <start/stop>
+susy.command.horde.start.usage=Usage: /mobHorde start <name>
+susy.command.horde.start.no_such_horde=No such horde %s exists.
+
+
+

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -749,8 +749,9 @@ susy.recipe.dimensions=Dimensions: %s
 
 susy.command.horde.usage=/mobHorde <start/stop>
 susy.command.horde.start.usage=/mobHorde start <name>
+susy.command.horde.start.argument_required=Use /mobHorde start <name>.
 susy.command.horde.start.no_such_horde=No such horde %s exists.
-susy.command.horde.start.unable_to_run=The %s horde can't be executed. This may be due to dimensional restrictions, daylight,...
+susy.command.horde.start.unable_to_run=The %s horde can't be executed. This may be due to dimensional restrictions, daylight, etc.
 susy.command.horde.start.error_executing_horde=Horde mobs were not spawned correctly.
 susy.command.horde.start.has_active_invasion=You already have an active %s invasion.
 susy.command.horde.start.started=Successfully started %s invasion.


### PR DESCRIPTION
## What
Adds commands to trigger and stop invasions.

## Implementation Details
Now stores the current active mob horde and a list of entities in the player data. The list gets populated via a callback that gets passed to the actual event and subsequently the spawning logic. The events have been given a name as identifier. 
In order to figure out when an invasion is defeated, we listen to the onEntityDeath event, which is probably not the ideal way. If anyone has any better ideas, I am open for suggestions.

## Outcome
The two commands /mobHorde start <name> and /mobHorde stop can now be used. 

## Additional Information
Also, invasions are now blocked from spawning as long as the previous one has not yet been defeated. This may be exploitable by trapping one entity indefinetely. This could be circumvented by forcibly stopping an invasion after a set timer runs out.
