### PR TITLE
thread fixes

### DIFF
--- a/src/main/java/supersymmetry/loaders/recipes/SuSyMaterialRecipeHandler.java
+++ b/src/main/java/supersymmetry/loaders/recipes/SuSyMaterialRecipeHandler.java
@@ -82,6 +82,7 @@ public class SuSyMaterialRecipeHandler {
                 .inputs(OreDictUnifier.get(SusyOrePrefix.fiber, mat, 4))
                 .fluidInputs(Air.getFluid(100))
                 .outputs(OreDictUnifier.get(threadPrefix, mat, 1))
+                .circuitMeta(1)
                 .duration(20)
                 .EUt(VA[LV])
                 .buildAndRegister();


### PR DESCRIPTION
this stops the thread rayon recipes from conflict with bed recipes:
![image](https://github.com/SymmetricDevs/Susy-Core/assets/51245052/5195dffc-3825-47cc-95a8-6eb184c49235)
