### PR TITLE
Weatherproof Mining Drill

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMiningDrill.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMiningDrill.java
@@ -88,6 +88,12 @@ public class MetaTileEntityMiningDrill extends RecipeMapMultiblockController {
         return SusyTextures.MINING_DRILL_OVERLAY;
     }
 
+    @Override
+    public boolean isMultiblockPartWeatherResistant(@Nonnull IMultiblockPart part) {
+        return true;
+    }
+
+
     @Nonnull
     protected TraceabilityPredicate depositPredicate() {
         return new TraceabilityPredicate(blockWorldState -> {


### PR DESCRIPTION
add isMultiblockPartWeatherResistant boolean to the Mining Drill Structure to prevent it from Exploding upon being rained on