### PR TITLE
Drop pod fixes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,10 +24,10 @@ dependencies {
     // CCL 3.2.3.358
     implementation rfg.deobf('curse.maven:codechicken-lib-1-8-242818:2779848')
     // GTCEu 2.8.7 beta
-    implementation rfg.deobf("curse.maven:gregtech-ce-unofficial-557242:5121638-deobf-5121638-sources-5121638")
+    //implementation rfg.deobf("curse.maven:gregtech-ce-unofficial-557242:5121638-deobf-5121638-sources-5121638")
     // GCYM 1.2.8
     implementation rfg.deobf('curse.maven:gregicality-multiblocks-564858:5121714-deobf-5121714-sources-5121714')
-
+    implementation files("libs/gregtech-1.12.2-2.8.7-beta.jar")
     // AE2UEL 0.55.6 (transitive gt dep)
     compileOnly rfg.deobf("curse.maven:ae2-extended-life-570458:4402048")
 
@@ -52,5 +52,5 @@ dependencies {
     implementation rfg.deobf("curse.maven:immersive-railroading-277736:4970105") // Immersive-Railroading v1.10.0
 
     implementation rfg.deobf("curse.maven:ctm-267602:2915363") // CTM 1.0.2.31
-    implementation rfg.deobf("curse.maven:groovyscript-687577:4991701") // GRS 0.7.3
+    implementation rfg.deobf("curse.maven:groovyscript-687577:5439031") // GRS 1.1.0
 }

--- a/src/main/java/supersymmetry/client/renderer/particles/SusyParticleSmoke.java
+++ b/src/main/java/supersymmetry/client/renderer/particles/SusyParticleSmoke.java
@@ -15,6 +15,8 @@ public class SusyParticleSmoke extends ParticleSmokeNormal {
         super(worldIn, xCoordIn, yCoordIn, zCoordIn, xSpeedIn, ySpeedIn, zSpeedIn, 3.F);
     }
 
+
+
     @SideOnly(Side.CLIENT)
     public static class Factory implements IParticleFactory {
 

--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -5,6 +5,7 @@ import gregtech.api.unification.material.event.MaterialEvent;
 import gregtech.api.unification.material.event.PostMaterialEvent;
 import gregtech.common.items.MetaItems;
 import net.minecraft.block.Block;
+import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.crafting.IRecipe;
@@ -16,6 +17,7 @@ import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib3.GeckoLib;
 import supersymmetry.Supersymmetry;
+import supersymmetry.api.event.MobHordeEvent;
 import supersymmetry.api.recipes.SuSyRecipeMaps;
 import supersymmetry.api.unification.ore.SusyOrePrefix;
 import supersymmetry.api.unification.ore.SusyStoneTypes;
@@ -45,7 +47,7 @@ public class CommonProxy {
 
     public void load() {
         SuSyWorldLoader.init();
-        //new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8, "zombies").setMaximumDistanceUnderground(10).setNightOnly(true);
+        new MobHordeEvent((p) -> new EntityZombie(p.world), 4, 8, "zombies").setMaximumDistanceUnderground(10).setNightOnly(true);
     }
 
     @SubscribeEvent

--- a/src/main/java/supersymmetry/common/entities/EntityDropPod.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDropPod.java
@@ -255,6 +255,9 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
                     }
                 }
                 this.setTimeSinceLanding(this.getTimeSinceLanding() + 1);
+                if (this.getTimeSinceLanding() > 1000) {
+                    this.setDead();
+                }
             }
 
             if (this.hasTakenOff()) {
@@ -317,7 +320,7 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
 
     @Override
     protected boolean canDespawn() {
-        return false;
+        return this.getTimeSinceLanding() > 1000;
     }
 
     @Override

--- a/src/main/java/supersymmetry/common/entities/EntityDropPod.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDropPod.java
@@ -391,7 +391,7 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
     }
 
     @Override
-    public boolean canBeSteered() {
+    public boolean canPassengerSteer() {
         return false;
     }
 }

--- a/src/main/java/supersymmetry/common/entities/EntityDropPod.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDropPod.java
@@ -189,7 +189,11 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
     }
 
     private void explode() {
-        this.world.newExplosion(this, this.posX, this.posY, this.posZ, 6, true, true);
+        int explosionStrength = 2;
+        if (getRidingEntity() != null && getRidingEntity() instanceof EntityPlayer) {
+            explosionStrength = 6;
+        }
+        this.world.newExplosion(this, this.posX, this.posY, this.posZ, explosionStrength, true, true);
         this.setDead();
     }
 
@@ -381,5 +385,10 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
     public void setupDropPodSound() {
         this.soundDropPod = new MovingSoundDropPod(this);
         Minecraft.getMinecraft().getSoundHandler().playSound(this.soundDropPod);
+    }
+
+    @Override
+    public boolean canBeSteered() {
+        return false;
     }
 }

--- a/src/main/java/supersymmetry/common/entities/EntityDropPod.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDropPod.java
@@ -248,8 +248,7 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
                     int posZRounded = MathHelper.floor(this.posZ);
                     IBlockState blockBeneath = this.world.getBlockState(new BlockPos(posXRounded, posYBeneath, posZRounded));
 
-                    if (blockBeneath.getMaterial() != Material.AIR)
-                    {
+                    if (blockBeneath.getMaterial() != Material.AIR) {
                         SoundType soundType = blockBeneath.getBlock().getSoundType(blockBeneath, world, new BlockPos(posXRounded, posYBeneath, posZRounded), this);
                         this.playSound(soundType.getBreakSound(), soundType.getVolume() * 3.0F, soundType.getPitch() * 0.2F);
                     }
@@ -298,6 +297,9 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
     protected void removePassenger(@NotNull Entity passenger) {
         if (this.canPlayerDismount()) {
             super.removePassenger(passenger);
+            if (passenger instanceof EntityLiving living) {
+                living.setNoAI(false);
+            }
         }
     }
 
@@ -306,10 +308,10 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
         super.updatePassenger(passenger);
         float xOffset = MathHelper.sin(this.renderYawOffset * 0.1F);
         float zOffset = MathHelper.cos(this.renderYawOffset * 0.1F);
-        passenger.setPosition(this.posX + (double)(0.1F * xOffset), this.posY + (double)(this.height * 0.2F) + passenger.getYOffset() + 0.0D, this.posZ - (double)(0.1F * zOffset));
+        passenger.setPosition(this.posX + (double) (0.1F * xOffset), this.posY + (double) (this.height * 0.2F) + passenger.getYOffset() + 0.0D, this.posZ - (double) (0.1F * zOffset));
 
         if (passenger instanceof EntityLivingBase) {
-            ((EntityLivingBase)passenger).renderYawOffset = this.renderYawOffset;
+            ((EntityLivingBase) passenger).renderYawOffset = this.renderYawOffset;
         }
     }
 
@@ -372,9 +374,14 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
 
     @Override
     protected void addPassenger(Entity passenger) {
-        if (this.getPassengers().isEmpty())
+        if (this.getPassengers().isEmpty()) {
             super.addPassenger(passenger);
+            if (passenger instanceof EntityLiving living) {
+                living.setNoAI(true);
+            }
+        }
     }
+
 
     @Override
     public void onAddedToWorld() {
@@ -390,8 +397,5 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
         Minecraft.getMinecraft().getSoundHandler().playSound(this.soundDropPod);
     }
 
-    @Override
-    public boolean canPassengerSteer() {
-        return false;
-    }
+
 }


### PR DESCRIPTION
Lowers the drop pod's explosion strength when it isn't carrying a player, and prevents it from being ridden by a zombie.