### PR TITLE
"fix" the BDS&M barrel kick bug

### DIFF
--- a/src/main/java/supersymmetry/mixins/bdsandm/ItemBarrelMixin.java
+++ b/src/main/java/supersymmetry/mixins/bdsandm/ItemBarrelMixin.java
@@ -1,0 +1,36 @@
+package supersymmetry.mixins.bdsandm;
+
+import funwayguy.bdsandm.inventory.capability.BdsmCapabilies;
+import funwayguy.bdsandm.inventory.capability.CapabilityBarrel;
+import funwayguy.bdsandm.items.ItemBarrel;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(ItemBarrel.class)
+public class ItemBarrelMixin extends ItemBlock {
+    //Need to extend ItemBlock to use super.getNBTShareTag
+    public ItemBarrelMixin(Block block) {
+        super(block);
+    }
+
+    /**
+     * @author The-Minecraft-Scientist (discord rsci.)
+     */
+    @Override
+    // Hack that keeps a difficult to reproduce bug somewhere else in BDS&M from kicking players.
+    // This hack omits adding the CapabilityBarrel NBT tag if CapabilityBarrel is not present on the given item stack.
+    // The original BDS&M code had an assertion that assumed barrelCap was non-null, which would
+    // fire from the network handler for a given player and kick them.
+    // This hack reduces the scope of the bug to incorrect (not present) barrel metadata on the client.
+    public NBTTagCompound getNBTShareTag(ItemStack stack) {
+        CapabilityBarrel barrelCap = (CapabilityBarrel) stack.getCapability(BdsmCapabilies.BARREL_CAP, null);
+        if (barrelCap == null) {
+            return super.getNBTShareTag(stack);
+        }
+        stack.setTagInfo("barrelCap", barrelCap.serializeNBT());
+        return super.getNBTShareTag(stack);
+    }
+}

--- a/src/main/resources/mixins.susy.late.json
+++ b/src/main/resources/mixins.susy.late.json
@@ -1,18 +1,19 @@
 {
-  "package" : "supersymmetry.mixins",
-  "refmap" : "mixins.susy.refmap.json",
-  "target" : "@env(DEFAULT)",
-  "minVersion" : "0.8",
-  "compatibilityLevel" : "JAVA_8",
-  "mixins" : [
+  "package": "supersymmetry.mixins",
+  "refmap": "mixins.susy.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
     "bdsandm.BlockBarrelBaseMixin",
+    "bdsandm.ItemBarrelMixin",
     "gregtech.BlockMachineMixin",
     "rftools.InventoryInfoMixin",
     "rftools.PacketGetInventoryInfoMixin",
     "rftools.PacketReturnInventoryInfoMixin"
   ],
-  "client" : [
+  "client": [
     "rftools.GuiStorageScannerMixin"
   ],
-  "server" : []
+  "server": []
 }


### PR DESCRIPTION
This is a hack reduces the severity of a very difficult to reproduce bug in BDS&M where one player holding a BDS&M barrel in their hand would disconnect other players on a multiplayer server.
The underlying bug is that sometimes barrel item stacks passed to `getNBTShareTag` do not have the `CapabilityBarrel` capability in their capability list.

Where an assert in BDS&M's `getNBTShareTag` would cause the network handler task for whatever player the server was sending the share tag to error (kicking the player), my hack simply skips injecting barrel metadata into the NBT if the capability is not present (see the comment in `ItemBarrelMixin` for more info).
