### PR TITLE
Use frame predicate & static states

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityBlender.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityBlender.java
@@ -63,7 +63,7 @@ public class MetaTileEntityBlender extends RecipeMapMultiblockController {
                 .where('X', casing.or(abilities))
                 .where('P', states(getPipeCasingState()))
                 .where('D', states(MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.STAINLESS_CLEAN))) 
-                .where('E', states(MetaBlocks.FRAMES.get(Materials.StainlessSteel).getBlock(Materials.StainlessSteel)))
+                .where('E', frames(Materials.StainlessSteel))
                 .where('C', states(MetaBlocks.TURBINE_CASING.getState(TurbineCasingType.STAINLESS_STEEL_GEARBOX)))
                 .where(' ', any())
                 .build();
@@ -75,11 +75,11 @@ public class MetaTileEntityBlender extends RecipeMapMultiblockController {
         return Textures.INERT_PTFE_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.PTFE_INERT_CASING);
     }
 
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BlockBoilerCasing.BoilerCasingType.POLYTETRAFLUOROETHYLENE_PIPE);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCatalyticReformer.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCatalyticReformer.java
@@ -41,7 +41,7 @@ public class MetaTileEntityCatalyticReformer extends RecipeMapMultiblockControll
                         .setMinGlobalLimited(24)
                         .or(autoAbilities(true, true, true, true, true, true, false)))
                 .where('P', states(MetaBlocks.BOILER_CASING.getState(BlockBoilerCasing.BoilerCasingType.TITANIUM_PIPE)))
-                .where('F', states(MetaBlocks.FRAMES.get(Materials.Titanium).getBlock(Materials.Titanium)))
+                .where('F', frames(Materials.Titanium))
                 .where('M', abilities(MultiblockAbility.MUFFLER_HATCH))
                 .where(' ', any())
                 .where('#', air())

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityClarifier.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityClarifier.java
@@ -64,7 +64,7 @@ public class MetaTileEntityClarifier extends RecipeMapMultiblockController {
                 .where('C', states(MetaBlocks.BOILER_CASING.getState((BoilerCasingType.STEEL_PIPE))))
                 .where('D', states(SuSyBlocks.MULTIBLOCK_TANK.getState(BlockMultiblockTank.MultiblockTankType.CLARIFIER)))
                 .where('E', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)))
-                .where('F', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('F', frames(Materials.Steel))
                 .where(' ', any())
                 .build();
     }

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCokingTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCokingTower.java
@@ -53,7 +53,7 @@ public class MetaTileEntityCokingTower extends RecipeMapMultiblockController {
                 .aisle("  FF FF", "       ")
                 .where('S', this.selfPredicate())
                 .where('P', states(this.getPipeCasingState()))
-                .where('F', states(this.getFrameState()))
+                .where('F', frames(Materials.Steel))
                 .where('C', states(this.getCasingState()).setMinGlobalLimited(20)
                         .or(this.autoAbilities()))
                 .build();
@@ -61,13 +61,11 @@ public class MetaTileEntityCokingTower extends RecipeMapMultiblockController {
     public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {
         return Textures.SOLID_STEEL_CASING;
     }
-    protected IBlockState getFrameState() {
-        return MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel);
-    }
-    protected IBlockState getCasingState() {
+
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID);
     }
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCoolingUnit.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCoolingUnit.java
@@ -51,8 +51,8 @@ public class MetaTileEntityCoolingUnit extends RecipeMapMultiblockController {
                 .where('S', selfPredicate())
                 .where('A', casingPredicate
                         .or(autoAbilities(true, true, true, true, true, true, false)))
-                .where('B', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
-                .where('C', states(MetaBlocks.FRAMES.get(Materials.StainlessSteel).getBlock(Materials.StainlessSteel)))
+                .where('B', frames(Materials.Steel))
+                .where('C', frames(Materials.StainlessSteel))
                 .where('D', states(MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE)))
                 .where('E', casingPredicate)
                 .where(' ', any())

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityDumper.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityDumper.java
@@ -64,7 +64,7 @@ public class MetaTileEntityDumper extends VoidingMultiblockBase {
                 .aisle("BBBB", "C##A", "BBBB")
                 .aisle("A  A", "BSBB", "A  A")
                 .where('S', selfPredicate())
-                .where('A', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('A', frames(Materials.Steel))
                 .where('B', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID)))
                 .where('C', abilities(MultiblockAbility.IMPORT_FLUIDS).setExactLimit(1))
                 .where(' ', any())

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityElectrolyticCell.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityElectrolyticCell.java
@@ -54,10 +54,10 @@ public class MetaTileEntityElectrolyticCell extends RecipeMapMultiblockControlle
         return Textures.SOLID_STEEL_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID);
     }
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityFermentationVat.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityFermentationVat.java
@@ -40,7 +40,7 @@ public class MetaTileEntityFermentationVat extends RecipeMapMultiblockController
                 .where('X', states(MetaBlocks.MACHINE_CASING.getState(MachineCasingType.ULV))
                         .setMinGlobalLimited(40)
                         .or(autoAbilities(true, true, true, true, true, true, false)))
-                .where('F', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('F', frames(Materials.Steel))
                 .where('M', abilities(MultiblockAbility.MUFFLER_HATCH))
                 .where(' ', any())
                 .where('#', air())

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityFlareStack.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityFlareStack.java
@@ -213,7 +213,7 @@ public class MetaTileEntityFlareStack extends VoidingMultiblockBase {
         return Textures.SOLID_STEEL_CASING;
     }
 
-    protected IBlockState getFireboxCasingState() {
+    protected static IBlockState getFireboxCasingState() {
         return MetaBlocks.BOILER_FIREBOX_CASING.getState(BlockFireboxCasing.FireboxCasingType.STEEL_FIREBOX);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityFluidizedBedReactor.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityFluidizedBedReactor.java
@@ -42,7 +42,7 @@ public class MetaTileEntityFluidizedBedReactor extends RecipeMapMultiblockContro
                 .aisle("   ", "XPX", "XPX", "XPX", "XPX")
                 .aisle("F F", "XSX", "XXX", "XXX", "XXX")
                 .where('S', this.selfPredicate())
-                .where('F', states(this.getFrameState()))
+                .where('F', frames(Materials.Steel))
                 .where('P', states(this.getPipeCasingState()))
                 .where('X', states(this.getCasingState()).setMinGlobalLimited(18)
                         .or(this.autoAbilities(true, true, true, true, true, true, false)))
@@ -52,14 +52,11 @@ public class MetaTileEntityFluidizedBedReactor extends RecipeMapMultiblockContro
         return Textures.INERT_PTFE_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.PTFE_INERT_CASING);
     }
-    protected IBlockState getFrameState() {
-        return MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel);
-    }
 
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BoilerCasingType.POLYTETRAFLUOROETHYLENE_PIPE);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHeatExchanger.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHeatExchanger.java
@@ -45,7 +45,7 @@ public class MetaTileEntityHeatExchanger extends RecipeMapMultiblockController {
                 .aisle("CCC", "CDC", "ACA")
                 .aisle("CCC", "BSB", "ACA")
                 .where('S', selfPredicate())
-                .where('A', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('A', frames(Materials.Steel))
                 .where('B', autoAbilities(false, false, false, false, false, true, false).setMinGlobalLimited(2)
                         .or(autoAbilities(false, false, false, false, true, false, false).setMinGlobalLimited(2)))
                 .where('C', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighPressureCryogenicDistillationPlant.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighPressureCryogenicDistillationPlant.java
@@ -64,7 +64,7 @@ public class MetaTileEntityHighPressureCryogenicDistillationPlant extends Recipe
         return Textures.FROST_PROOF_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.ALUMINIUM_FROSTPROOF);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighTemperatureDistillationTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighTemperatureDistillationTower.java
@@ -70,7 +70,7 @@ public class MetaTileEntityHighTemperatureDistillationTower extends RecipeMapMul
         return SusyTextures.SILICON_CARBIDE_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return SuSyBlocks.MULTIBLOCK_CASING.getState(BlockSuSyMultiblockCasing.CasingType.SILICON_CARBIDE_CASING);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityLargeWeaponsFactory.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityLargeWeaponsFactory.java
@@ -48,7 +48,7 @@ public class MetaTileEntityLargeWeaponsFactory extends RecipeMapMultiblockContro
                 .where('S', selfPredicate())
                 .where('A', casingPredicate)
                 .where('B', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)))
-                .where('C', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel))
+                .where('C', frames(Materials.Steel)
                         .or(autoAbilities(false, true, false, false, false, false, false).setExactLimit(1)))
                 .where('D', casingPredicate
                         .or(autoAbilities(false, false, true, false, true, false, false)))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityLowPressureCryogenicDistillationPlant.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityLowPressureCryogenicDistillationPlant.java
@@ -83,7 +83,7 @@ public class MetaTileEntityLowPressureCryogenicDistillationPlant extends RecipeM
         return Textures.FROST_PROOF_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.ALUMINIUM_FROSTPROOF);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMiningDrill.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMiningDrill.java
@@ -5,6 +5,7 @@ import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
@@ -65,7 +66,7 @@ public class MetaTileEntityMiningDrill extends RecipeMapMultiblockController {
                 .aisle("               ", "     DDDDD     ", "     DDDDD     ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ")
                 .where('S', selfPredicate())
                 .where('A', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID)))
-                .where('B', frames(Materials.Steel).setMinGlobalLimited(275)
+                .where('B', frames(Materials.Steel)
                         .or(autoAbilities(true, true, true, true, true, true, false)))
                 .where('C', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)))
                 .where('D', states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT)))
@@ -76,6 +77,33 @@ public class MetaTileEntityMiningDrill extends RecipeMapMultiblockController {
                 .where(' ', any())
                 .build();
     }
+
+    @Override
+    public TraceabilityPredicate autoAbilities(boolean checkEnergyIn, boolean checkMaintenance, boolean checkItemIn, boolean checkItemOut, boolean checkFluidIn, boolean checkFluidOut, boolean checkMuffler) {
+        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler);
+        if (checkEnergyIn) {
+            predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2).setPreviewCount(1));
+        }
+
+        if (checkItemIn && this.recipeMap.getMaxInputs() > 0) {
+            predicate = predicate.or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(2).setPreviewCount(1));
+        }
+
+        if (checkItemOut && this.recipeMap.getMaxOutputs() > 0) {
+            predicate = predicate.or(abilities(MultiblockAbility.EXPORT_ITEMS).setMaxGlobalLimited(2).setPreviewCount(1));
+        }
+
+        if (checkFluidIn && this.recipeMap.getMaxFluidInputs() > 0) {
+            predicate = predicate.or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMaxGlobalLimited(2).setPreviewCount(1));
+        }
+
+        if (checkFluidOut && this.recipeMap.getMaxFluidOutputs() > 0) {
+            predicate = predicate.or(abilities(MultiblockAbility.EXPORT_FLUIDS).setMaxGlobalLimited(2).setPreviewCount(1));
+        }
+
+        return predicate;
+    }
+
 
     @Override
     public ICubeRenderer getBaseTexture(IMultiblockPart iMultiblockPart) {
@@ -171,5 +199,10 @@ public class MetaTileEntityMiningDrill extends RecipeMapMultiblockController {
     @Override
     public boolean allowsExtendedFacing() {
         return false;
+    }
+
+    @Override
+    public boolean allowsFlip() {
+        return true;
     }
 }

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMiningDrill.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMiningDrill.java
@@ -65,7 +65,7 @@ public class MetaTileEntityMiningDrill extends RecipeMapMultiblockController {
                 .aisle("               ", "     DDDDD     ", "     DDDDD     ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ", "               ")
                 .where('S', selfPredicate())
                 .where('A', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID)))
-                .where('B', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)).setMinGlobalLimited(275)
+                .where('B', frames(Materials.Steel).setMinGlobalLimited(275)
                         .or(autoAbilities(true, true, true, true, true, true, false)))
                 .where('C', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)))
                 .where('D', states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT)))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMultiStageFlashDistiller.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMultiStageFlashDistiller.java
@@ -59,7 +59,7 @@ public class MetaTileEntityMultiStageFlashDistiller extends RecipeMapMultiblockC
                 .aisle(" FFF ", " FSF ", " FFF ", " FFF ", "  B  ")
                 .where('S', selfPredicate())
                 .where('B', states(MetaBlocks.BOILER_CASING.getState((BlockBoilerCasing.BoilerCasingType.STEEL_PIPE))))
-                .where('C', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('C', frames(Materials.Steel))
                 .where('A', casingPredicate
                         .or(maintenanceEnergy))
                 .where('D', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.STAINLESS_CLEAN))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityOceanPumper.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityOceanPumper.java
@@ -307,19 +307,19 @@ public class MetaTileEntityOceanPumper extends MultiblockWithDisplayBase impleme
         return SusyTextures.OCEANIC_DRILL_OVERLAY;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.STEEL_SOLID);
     }
 
-    protected IBlockState getGrateState() {
+    protected static IBlockState getGrateState() {
         return MetaBlocks.MULTIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.GRATE_CASING);
     }
 
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BlockBoilerCasing.BoilerCasingType.STEEL_PIPE);
     }
 
-    protected IBlockState getConcreteState() {
+    protected static IBlockState getConcreteState() {
         return MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityOreSorter.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityOreSorter.java
@@ -39,7 +39,7 @@ public class MetaTileEntityOreSorter extends RecipeMapMultiblockController {
                 .aisle("ABBBA", "B###B", "ABBBA", " D D ")
                 .aisle("ABSBA", "ABBBA", "ABBBA", " D D ")
                 .where('S', selfPredicate())
-                .where('A', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('A', frames(Materials.Steel))
                 .where('B', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID))
                         .setMinGlobalLimited(16)
                         .or(autoAbilities(true, true, true, true, false, false, false)))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPolmyerizationTank.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPolmyerizationTank.java
@@ -41,7 +41,7 @@ public class MetaTileEntityPolmyerizationTank extends RecipeMapMultiblockControl
                 .aisle("   ", "XPX", "XPX", "XPX", "XPX")
                 .aisle("F F", "XSX", "XXX", "XXX", "XXX")
                 .where('S', this.selfPredicate())
-                .where('F', states(this.getFrameState()))
+                .where('F', frames(Materials.Steel))
                 .where('P', states(this.getPipeCasingState()))
                 .where('X', states(this.getCasingState()).setMinGlobalLimited(18)
                         .or(this.autoAbilities(true, true, true, true, true, true, false)))
@@ -51,14 +51,11 @@ public class MetaTileEntityPolmyerizationTank extends RecipeMapMultiblockControl
         return Textures.SOLID_STEEL_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID);
     }
-    protected IBlockState getFrameState() {
-        return MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel);
-    }
 
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuencher.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuencher.java
@@ -47,7 +47,7 @@ public class MetaTileEntityQuencher extends RecipeMapMultiblockController {
                 .where('A', casingPredicate)
                 .where('B', states(MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE)))
                 .where('C', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STAINLESS_STEEL_GEARBOX)))
-                .where('D', states(MetaBlocks.FRAMES.get(Materials.StainlessSteel).getBlock(Materials.StainlessSteel)))
+                .where('D', frames(Materials.StainlessSteel))
                 .where('F', autoAbilities(false, false, false, false, false, true, false).setExactLimit(1)
                         .or(autoAbilities(false, false, false, false, true, false, false).setExactLimit(1)))
                 .where('G', casingPredicate

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityRailroadEngineeringStation.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityRailroadEngineeringStation.java
@@ -129,7 +129,7 @@ public class MetaTileEntityRailroadEngineeringStation extends RecipeMapMultibloc
                 .aisle("                 ", "                 ", "                 ", "                 ", "                 ", "                 ", "                 ", "                 ", "       F F       ", "                 ")
                 .aisle("                 ", "                 ", "                 ", "                 ", "                 ", "                 ", "                 ", "                 ", "       F F       ", "                 ")
                 .where('S', selfPredicate())
-                .where('F', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('F', frames(Materials.Steel))
                 .where('M', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID)))
                 .where('G', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)))
                 .where('C', states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT)))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityReactionFurnace.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityReactionFurnace.java
@@ -49,7 +49,7 @@ public class MetaTileEntityReactionFurnace extends RecipeMapMultiblockController
                 .where('X', states(MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.INVAR_HEATPROOF)).setMinGlobalLimited(13)
                         .or(autoAbilities(true, true, true, true, true, true, false)))
                 .where('P', states(MetaBlocks.BOILER_CASING.getState(BlockBoilerCasing.BoilerCasingType.STEEL_PIPE)))
-                .where('F', states(MetaBlocks.FRAMES.get(Materials.Invar).getBlock(Materials.Invar)))
+                .where('F', frames(Materials.Invar))
                 .where('M', abilities(MultiblockAbility.MUFFLER_HATCH))
                 .where('B', states(MetaBlocks.BOILER_FIREBOX_CASING.getState(BlockFireboxCasing.FireboxCasingType.STEEL_FIREBOX)))
                 .where('#', air())

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityRotaryKiln.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityRotaryKiln.java
@@ -59,7 +59,7 @@ public class MetaTileEntityRotaryKiln extends RecipeMapMultiblockController {
                 .aisle("A    A    A", "A    A    A", "LCCCCMCCCCR", "L#########R", "LCCCCMCCCCR")
                 .aisle("A    A    A", "A    A    A", "L    A    R", "LCCCCSCCCCR", "L    A    R")
                 .where('S', selfPredicate())
-                .where('A', states(MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel)))
+                .where('A', frames(Materials.Steel))
                 .where('C', states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT)))
                 .where('L', casingPredicate
                         .or(autoAbilities(false, false, true, false, false, true, false))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySingleColumnCryogenicDistillationPlant.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySingleColumnCryogenicDistillationPlant.java
@@ -84,7 +84,7 @@ public class MetaTileEntitySingleColumnCryogenicDistillationPlant extends Recipe
         return Textures.FROST_PROOF_CASING;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.ALUMINIUM_FROSTPROOF);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySinteringOven.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySinteringOven.java
@@ -12,9 +12,6 @@ import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.unification.material.Materials;
 import gregtech.client.renderer.ICubeRenderer;
-import gregtech.client.renderer.texture.Textures;
-import gregtech.common.blocks.BlockMachineCasing;
-import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
@@ -68,12 +65,8 @@ public class MetaTileEntitySinteringOven extends RecipeMapMultiblockController {
         return SusyTextures.SINTERING_OVERLAY;
     }
 
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return SuSyBlocks.MULTIBLOCK_CASING.getState(BlockSuSyMultiblockCasing.CasingType.ULV_STRUCTURAL_CASING);
-    }
-
-    protected IBlockState getFrameState() {
-        return MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel);
     }
 
     @NotNull
@@ -99,7 +92,7 @@ public class MetaTileEntitySinteringOven extends RecipeMapMultiblockController {
                         .or(autoAbilities(true, true, false, true, true, false, false)))
                 .where('C', casingPredicate
                         .or(autoAbilities(false, false, true, false, false, true, false)))
-                .where('F', states(getFrameState()))
+                .where('F', frames(Materials.Steel))
                 .where('B', SuSyPredicates.sinteringBricks())
                 .where('#', air())
                 .where(' ', any())

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySmokeStack.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySmokeStack.java
@@ -194,7 +194,7 @@ public class MetaTileEntitySmokeStack extends VoidingMultiblockBase {
     public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {
         return Textures.SOLID_STEEL_CASING;
     }
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE);
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityVacuumDistillationTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityVacuumDistillationTower.java
@@ -51,7 +51,7 @@ public class MetaTileEntityVacuumDistillationTower extends RecipeMapMultiblockCo
                 .where('S', this.selfPredicate())
                 .where('G', states(this.getGlassState()))
                 .where('P', states(this.getPipeCasingState()))
-                .where('F', states(this.getFrameState()))
+                .where('F', frames(Materials.Steel))
                 .where('C', states(this.getCasingState())
                         .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMaxGlobalLimited(1))
@@ -70,16 +70,14 @@ public class MetaTileEntityVacuumDistillationTower extends RecipeMapMultiblockCo
     public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {
         return Textures.SOLID_STEEL_CASING;
     }
-    protected IBlockState getFrameState() {
-        return MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel);
-    }
-    protected IBlockState getGlassState() {
+
+    protected static IBlockState getGlassState() {
         return MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.TEMPERED_GLASS);
     }
-    protected IBlockState getCasingState() {
+    protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID);
     }
-    protected IBlockState getPipeCasingState() {
+    protected static IBlockState getPipeCasingState() {
         return MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE);
     }
 


### PR DESCRIPTION
This PR:

- make susy multis use `frames()` predicate to enable players using framed pipes in the structure.
- makes most `getCasingState()` or alike methods static, probably better in performance.

This has been tested in a dev environment.

*Note*: there is a ceu issue https://github.com/GregTechCEu/GregTech/issues/2582 where you can remove the frames from pipes in structure without Invalidizating the multis.