### PR TITLE
Fix Homeblock

### DIFF
--- a/src/main/java/supersymmetry/common/blocks/BlockHome.java
+++ b/src/main/java/supersymmetry/common/blocks/BlockHome.java
@@ -1,31 +1,24 @@
 package supersymmetry.common.blocks;
 
-import gregtech.api.block.VariantBlock;
-import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
-import net.minecraft.block.properties.PropertyDirection;
-import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.*;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
+import supersymmetry.api.blocks.VariantHorizontalRotatableBlock;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class BlockHome extends VariantBlock<BlockHome.HomeType> {
-
-    public static final PropertyDirection FACING = BlockHorizontal.FACING;
+public class BlockHome extends VariantHorizontalRotatableBlock<BlockHome.HomeType> {
 
     public BlockHome() {
         super(Material.IRON);
@@ -37,80 +30,34 @@ public class BlockHome extends VariantBlock<BlockHome.HomeType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos,
+                                    @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
     @Override
-    public boolean isBed(IBlockState state, IBlockAccess world, BlockPos pos, @Nullable Entity player) {
+    public boolean isBed(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @Nullable Entity player) {
         return true;
     }
 
-    public void onBlockPlacedBy(World worldIn, BlockPos pos, IBlockState state, EntityLivingBase placer, ItemStack stack) {
-        worldIn.setBlockState(pos, state.withProperty(FACING, placer.getHorizontalFacing().getOpposite()), 2);
-    }
-
-    public IBlockState getStateForPlacement(World worldIn, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer) {
-        return super.getStateForPlacement(worldIn, pos, facing, hitX, hitY, hitZ, meta, placer).withProperty(FACING, placer.getHorizontalFacing().getOpposite());
-    }
-
-    public IBlockState withRotation(IBlockState state, Rotation rot) {
-        return state.withProperty(FACING, rot.rotate((EnumFacing) state.getValue(FACING)));
-    }
-
-    public IBlockState withMirror(IBlockState state, Mirror mirrorIn) {
-        return state.withRotation(mirrorIn.toRotation((EnumFacing)state.getValue(FACING)));
-    }
-
-    public IBlockState getStateFromMeta(int meta) {
-        int i = meta / 4;
-        int j = meta % 4 + 2;
-
-        EnumFacing enumfacing = EnumFacing.byIndex(j);
-
-        if (enumfacing.getAxis() == EnumFacing.Axis.Y)
-        {
-            enumfacing = EnumFacing.NORTH;
-        }
-
-        return this.getDefaultState().withProperty(FACING, enumfacing).withProperty(this.VARIANT, this.VALUES[i % this.VALUES.length]);
-    }
-
-    public int getMetaFromState(IBlockState state) {
-        int i = ((Enum)state.getValue(this.VARIANT)).ordinal();
-        int j = ((EnumFacing)state.getValue(FACING)).getIndex();
-        return j - 2 + i * 4;
-    }
-
-    @Nonnull
-    protected BlockStateContainer createBlockState() {
-        super.createBlockState();
-
-        return new BlockStateContainer(this, new IProperty[]{this.VARIANT, this.FACING});
-    }
-
-    public ItemStack getItemVariant(BlockHome.HomeType variant, int amount) {
-        return new ItemStack(this, amount, variant.ordinal() * 4) ;
-    }
-
-    public int damageDropped(@Nonnull IBlockState state) {
-        return this.getMetaFromState(state) - ((EnumFacing)state.getValue(FACING)).getIndex() + 2;
-    }
-
     @Override
-    public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
-        if ((worldIn.provider.canRespawnHere() && worldIn.getBiome(pos) != net.minecraft.init.Biomes.HELL) && !worldIn.isRemote) {
-            playerIn.sendStatusMessage(new TextComponentTranslation("tile.home.allowed"), true);
+    public boolean onBlockActivated(World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull EntityPlayer playerIn,
+                                    @NotNull EnumHand hand, @NotNull EnumFacing facing, float hitX, float hitY, float hitZ) {
+        if (worldIn.isRemote) return true;
+        if ((worldIn.provider.canRespawnHere() && worldIn.getBiome(pos) != net.minecraft.init.Biomes.HELL)) {
             net.minecraftforge.event.ForgeEventFactory.onPlayerSpawnSet(playerIn, pos, true);
             playerIn.bedLocation = pos;
             playerIn.setSpawnPoint(playerIn.bedLocation, false);
+            playerIn.sendStatusMessage(new TextComponentTranslation("tile.home.allowed"), true);
+            return true;
         } else {
             playerIn.sendStatusMessage(new TextComponentTranslation("tile.home.denied"), true);
+            return false;
         }
-        return false;
     }
 
     public enum HomeType implements IStringSerializable {
+
         HOME_PRIMITIVE("home_primitive"),
         HOME_GT_BRUTALIST("home_gt_brutalist"),
         HOME_RENEWAL_BRUTALIST("home_renewal_brutalist"),
@@ -128,6 +75,7 @@ public class BlockHome extends VariantBlock<BlockHome.HomeType> {
             return this.name;
         }
 
+        @Override
         public String toString() {
             return this.getName();
         }


### PR DESCRIPTION
This PR:

- lets homeblock extend `VariantHorizontalRotatableBlock`, reducing the code it uses.
- fix the issue with double info display together by checking world side first.

<img width="128" alt="a3ab6a50299f4b67aa972294660f6616" src="https://github.com/user-attachments/assets/8093b5a9-aba6-4b3d-bffd-61a4306592e4">

- make homeblock feels like a real right-clickable block by acting correctly after right clicking, which means no more torch placing on homeblocks when you want to reset your spawn. (plz see code sorry for my broken English).
- some other code cleanups.

*Note*: this PR will rotate all existing homeblocks by certain degree, but without changing the type of them.

<img width="329" alt="{DA873F54-2AAE-4eda-894E-0B7A9AB43C8E}" src="https://github.com/user-attachments/assets/21b916f3-ab7a-49a3-b774-45762b0f8f90">
->
<img width="400" alt="{9F74AA4B-D8F3-4f9c-AD05-F3C48AECFBB7}" src="https://github.com/user-attachments/assets/418509fd-a7d0-4a96-b756-31628769b3f7">
