### PR TITLE
Bogosort Storage Scanners

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -62,4 +62,5 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:hwyla-253449:2568751")
 
     implementation rfg.deobf("curse.maven:barrels-drums-storage-more-319404:2708193")
+    implementation rfg.deobf("curse.maven:inventory-bogosorter-632327:5162169")
 }

--- a/src/main/java/supersymmetry/mixins/rftools/GuiStorageScannerMixin.java
+++ b/src/main/java/supersymmetry/mixins/rftools/GuiStorageScannerMixin.java
@@ -1,13 +1,18 @@
 package supersymmetry.mixins.rftools;
 
+import com.cleanroommc.bogosorter.common.sort.SortHandler;
 import com.llamalad7.mixinextras.sugar.Local;
 import mcjty.lib.gui.widgets.BlockRender;
 import mcjty.rftools.blocks.storagemonitor.GuiStorageScanner;
 import mcjty.rftools.blocks.storagemonitor.PacketReturnInventoryInfo;
+import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import supersymmetry.api.bugfixes.IItemStackInfo;
+
+import java.util.Comparator;
+import java.util.function.Function;
 
 @Mixin(GuiStorageScanner.class)
 public class GuiStorageScannerMixin {
@@ -19,5 +24,14 @@ public class GuiStorageScannerMixin {
                     ordinal = 0))
     private BlockRender setRenderItemCorrectly(BlockRender renderer, Object object, @Local(argsOnly = true) PacketReturnInventoryInfo.InventoryInfo info) {
         return renderer.setRenderItem(((IItemStackInfo) info).getStack());
+    }
+
+    @Redirect(method = "updateContentsList",
+            remap = false,
+            at = @At(value = "INVOKE",
+                    target = "Ljava/util/Comparator;comparing(Ljava/util/function/Function;)Ljava/util/Comparator;",
+                    ordinal = 0))
+    public Comparator<ItemStack> redirectComparator(Function<ItemStack, String> no_one_likes_alphabetical_order) {
+        return SortHandler.getClientItemComparator();
     }
 }


### PR DESCRIPTION
This PR:

- makes RFTools storage scanner sort its items based on the Inventory Bogosorter's logic instead of alphabetically.

*Note*: we're kinda bloating the `dependencies.gradle` too much. I'll do something to this later.