### PR TITLE
Fix drop pads leaving NoAI zombies when dropping into the water

### DIFF
--- a/src/main/java/supersymmetry/common/entities/EntityDropPod.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDropPod.java
@@ -29,7 +29,6 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
-import supersymmetry.api.SusyLog;
 import supersymmetry.client.audio.MovingSoundDropPod;
 import supersymmetry.client.renderer.particles.SusyParticleFlame;
 import supersymmetry.client.renderer.particles.SusyParticleSmoke;
@@ -298,11 +297,10 @@ public class EntityDropPod extends EntityLiving implements IAnimatable {
 
     @Override
     protected void removePassenger(@NotNull Entity passenger) {
-        if (this.canPlayerDismount()) {
-            super.removePassenger(passenger);
-            if (passenger instanceof EntityLiving living) {
-                living.setNoAI(false);
-            }
+        if (passenger instanceof EntityPlayer && !canPlayerDismount()) return;
+        super.removePassenger(passenger);
+        if (passenger instanceof EntityLiving living) {
+            living.setNoAI(false);
         }
     }
 


### PR DESCRIPTION
as the title says

this PR simply adds a check for the entity so that the entities can get their AI back properly after dismounting.