### PR TITLE
Necessary changes for mwc integration

### DIFF
--- a/src/api/java/crafttweaker/annotations/ZenRegister.java
+++ b/src/api/java/crafttweaker/annotations/ZenRegister.java
@@ -1,0 +1,11 @@
+package crafttweaker.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks that a class should be automatically registered with Crafttweaker.
+ * Combine with @{@link ModOnly} to automatically load the class if a mod is present
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface ZenRegister {}

--- a/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
+++ b/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
@@ -206,7 +206,8 @@ public class SuSyRecipeMaps {
 
     public static final RecipeMap<SimpleRecipeBuilder> LARGE_WEAPONS_FACTORY_RECIPES = new RecipeMap<>("large_weapons_factory", 9, 1, 3, 0, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_CIRCUIT, ProgressWidget.MoveType.HORIZONTAL)
-            .setSound(GTSoundEvents.ASSEMBLER);
+            .setSound(GTSoundEvents.ASSEMBLER)
+            .setSmallRecipeMap(WEAPONS_FACTORY_RECIPES);
 
     public static final RecipeMap<SimpleRecipeBuilder> RAILROAD_ENGINEERING_STATION_RECIPES = new RecipeMap<>("railroad_engineering_station", 16, 1, 4, 0, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, ProgressWidget.MoveType.HORIZONTAL)

--- a/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
+++ b/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
@@ -10,7 +10,6 @@ import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.unification.material.Materials;
 import gregtech.core.sound.GTSoundEvents;
 import gregtechfoodoption.recipe.GTFORecipeMaps;
-import supersymmetry.api.SusyLog;
 import supersymmetry.api.gui.SusyGuiTextures;
 import supersymmetry.api.recipes.builders.*;
 
@@ -354,6 +353,7 @@ public class SuSyRecipeMaps {
         RecipeMaps.CUTTER_RECIPES.setMaxOutputs(4);
         RecipeMaps.LARGE_CHEMICAL_RECIPES.setMaxInputs(4);
         RecipeMaps.LARGE_CHEMICAL_RECIPES.setMaxFluidInputs(6);
+        RecipeMaps.FORMING_PRESS_RECIPES.setMaxFluidInputs(1);
 
         SuSyRecipeMaps.EVAPORATION_POOL.recipeBuilder()
                 .fluidInputs(Materials.Water.getFluid(1000))

--- a/src/main/java/supersymmetry/mixins/gregtech/RecipeMapFormingPressMixin.java
+++ b/src/main/java/supersymmetry/mixins/gregtech/RecipeMapFormingPressMixin.java
@@ -1,0 +1,32 @@
+package supersymmetry.mixins.gregtech;
+
+import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.gui.ModularUI;
+import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.builders.SimpleRecipeBuilder;
+import gregtech.api.recipes.machines.RecipeMapFormingPress;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Deprecated
+@ScheduledForRemoval(inVersion = "Next CEu update") // not needed after MUI migration
+@Mixin(value = RecipeMapFormingPress.class)
+public class RecipeMapFormingPressMixin extends RecipeMap<SimpleRecipeBuilder> {
+
+    public RecipeMapFormingPressMixin(@NotNull String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, @NotNull SimpleRecipeBuilder defaultRecipeBuilder, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipeBuilder, isHidden);
+    }
+
+    @Inject(method = "addSlot", at = @At("HEAD"), cancellable = true, remap = false)
+    protected void addFluidSlot(ModularUI.Builder builder, int x, int y, int slotIndex, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isFluid, boolean isOutputs, CallbackInfo ci) {
+        if (isFluid) {
+            super.addSlot(builder, x, y, slotIndex, itemHandler, fluidHandler, true, isOutputs);
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/mixins.susy.late.json
+++ b/src/main/resources/mixins.susy.late.json
@@ -8,6 +8,7 @@
     "bdsandm.BlockBarrelBaseMixin",
     "bdsandm.ItemBarrelMixin",
     "gregtech.BlockMachineMixin",
+    "gregtech.RecipeMapFormingPressMixin",
     "rftools.InventoryInfoMixin",
     "rftools.PacketGetInventoryInfoMixin",
     "rftools.PacketReturnInventoryInfoMixin"


### PR DESCRIPTION
This PR contains codes that is necessary for the mwc integration. Currently it contains:

- a mixin into RecipeMapFormingPress to allow forming press to use fluid inputs. (this will be no longer needed after MUI migration)
- allows LWF to process WF recipes.