### PR TITLE
Remove Coil Activity Per Tick Update

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
@@ -665,7 +665,8 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
             return; //dont do logic on client
         }
 
-        setCoilActivity(false); // solves world issue reload where coils would be active even if multi was not running
+        // apparently causes significant lag; removal of this call will result in rendering issues due to super update concluding coils should be on innappropriately
+        // setCoilActivity(false); // solves world issue reload where coils would be active even if multi was not running
         if (structurePattern.getError() != null) return; //dont do processing for unformed multis
 
         //ensure timer is non-negative by anding sign bit with 0


### PR DESCRIPTION
Removes coil activity manual override/ update per tick to prevent visual issues; will cause incorrect activity status on coils, but should hopefully address apparent performance concerns.

Details:

Coils can start update as inactive state in spite of recipe running due to heating status of evap pool. super.update() only cares for recipe status, and so notices a discrepency and swaps the coils to on. This change must be re-corrected, or else the coils glow inappropriately.