### PR TITLE
Mixin into traveler's backpack

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -60,6 +60,7 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:redstone-flux-270789:2920436")
     compileOnly rfg.deobf("curse.maven:tesla-244651:2487959")
     compileOnly rfg.deobf("curse.maven:hwyla-253449:2568751")
+    compileOnly rfg.deobf("curse.maven:travelers-backpack-321117:3150850")
 
     compileOnly rfg.deobf("curse.maven:barrels-drums-storage-more-319404:2708193")
 }

--- a/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
+++ b/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 public class SuSyLateMixinLoader implements ILateMixinLoader {
 
-    public static final List<String> modMixins = ImmutableList.of("bdsandm", "gregtech", "mcjtylib_ng", "xnet");
+    public static final List<String> modMixins = ImmutableList.of("bdsandm", "gregtech", "mcjtylib_ng", "xnet", "travelersbackpack");
 
     @Override
     public List<String> getMixinConfigs() {

--- a/src/main/java/supersymmetry/mixins/travelersbackpack/GuiTravelersBackpackMixin.java
+++ b/src/main/java/supersymmetry/mixins/travelersbackpack/GuiTravelersBackpackMixin.java
@@ -1,0 +1,18 @@
+package supersymmetry.mixins.travelersbackpack;
+
+import com.tiviacz.travelersbackpack.gui.GuiTravelersBackpack;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = GuiTravelersBackpack.class, remap = false)
+public class GuiTravelersBackpackMixin {
+
+    @Redirect(method = "mouseClicked",
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper;sendToServer(Lnet/minecraftforge/fml/common/network/simpleimpl/IMessage;)V",
+                    ordinal = 0))
+    protected void noBedsForYa(SimpleNetworkWrapper instance, IMessage nope) {}
+}

--- a/src/main/java/supersymmetry/mixins/travelersbackpack/GuiTravelersBackpackMixin.java
+++ b/src/main/java/supersymmetry/mixins/travelersbackpack/GuiTravelersBackpackMixin.java
@@ -7,12 +7,13 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(value = GuiTravelersBackpack.class, remap = false)
+@Mixin(value = GuiTravelersBackpack.class)
 public class GuiTravelersBackpackMixin {
 
     @Redirect(method = "mouseClicked",
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper;sendToServer(Lnet/minecraftforge/fml/common/network/simpleimpl/IMessage;)V",
+                    remap = false,
                     ordinal = 0))
     protected void noBedsForYa(SimpleNetworkWrapper instance, IMessage nope) {}
 }

--- a/src/main/resources/mixins.susy.travelersbackpack.json
+++ b/src/main/resources/mixins.susy.travelersbackpack.json
@@ -1,0 +1,10 @@
+{
+  "package": "supersymmetry.mixins.travelersbackpack",
+  "refmap": "mixins.susy.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": [
+    "GuiTravelersBackpackMixin"
+  ]
+}


### PR DESCRIPTION
Mixin into GuiTravelersBackpack.class, stops sleepbag netbufs from ever being sent, thus disabling the function as a whole (the buttom is still there tho), which allows us to put backpacks before EV in the future.

This has been tested in a obf client environment.

plz tell me if there's a better way to handle this.