### PR TITLE
Allow jetpacks to be put into the bauble slots

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,5 +61,7 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:tesla-244651:2487959")
     compileOnly rfg.deobf("curse.maven:hwyla-253449:2568751")
 
+    compileOnly rfg.deobf("curse.maven:bubbles-a-baubles-fork-995393:5719448")
+
     compileOnly rfg.deobf("curse.maven:barrels-drums-storage-more-319404:2708193")
 }

--- a/src/main/java/supersymmetry/common/item/behavior/ArmorBaubleBehavior.java
+++ b/src/main/java/supersymmetry/common/item/behavior/ArmorBaubleBehavior.java
@@ -1,0 +1,21 @@
+package supersymmetry.common.item.behavior;
+
+import baubles.api.BaubleType;
+import gregtech.integration.baubles.BaubleBehavior;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public class ArmorBaubleBehavior extends BaubleBehavior {
+
+    public ArmorBaubleBehavior(BaubleType baubleType) {
+        super(baubleType);
+    }
+
+    @Override
+    public void onWornTick(ItemStack stack, EntityLivingBase player) {
+        if (stack != null && stack != ItemStack.EMPTY && player instanceof EntityPlayer entityPlayer) {
+            stack.getItem().onArmorTick(player.getEntityWorld(), entityPlayer, stack); // Redirects onWornTick() to onArmorTick()
+        }
+    }
+}

--- a/src/main/java/supersymmetry/integration/bubbles/BaublesModule.java
+++ b/src/main/java/supersymmetry/integration/bubbles/BaublesModule.java
@@ -1,0 +1,39 @@
+package supersymmetry.integration.bubbles;
+
+import baubles.api.BaubleType;
+import gregtech.api.GTValues;
+import gregtech.api.modules.GregTechModule;
+import gregtech.common.items.MetaItems;
+import gregtech.integration.IntegrationSubmodule;
+import net.minecraft.item.Item;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.jetbrains.annotations.NotNull;
+import supersymmetry.common.item.behavior.ArmorBaubleBehavior;
+import supersymmetry.modules.SuSyModules;
+
+import java.util.Collections;
+import java.util.List;
+
+@GregTechModule(
+        moduleID = SuSyModules.MODULE_BUBBLES,
+        containerID = GTValues.MODID,
+        modDependencies = "baubles",
+        name = "SuSy Baubles Integration",
+        description = "Baubles Integration Module")
+public class BaublesModule extends IntegrationSubmodule {
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void registerItems(RegistryEvent.Register<Item> event) {
+        MetaItems.SEMIFLUID_JETPACK.addComponents(new ArmorBaubleBehavior(BaubleType.BODY));
+        MetaItems.ELECTRIC_JETPACK.addComponents(new ArmorBaubleBehavior(BaubleType.BODY));
+        MetaItems.ELECTRIC_JETPACK_ADVANCED.addComponents(new ArmorBaubleBehavior(BaubleType.BODY));
+    }
+
+    @NotNull
+    @Override
+    public List<Class<?>> getEventBusSubscribers() {
+        return Collections.singletonList(BaublesModule.class);
+    }
+}

--- a/src/main/java/supersymmetry/modules/SuSyModules.java
+++ b/src/main/java/supersymmetry/modules/SuSyModules.java
@@ -6,6 +6,7 @@ import supersymmetry.Supersymmetry;
 public class SuSyModules implements IModuleContainer {
 
     public static final String MODULE_BDSAndM = "bdsandm_integration";
+    public static final String MODULE_BUBBLES = "baubles_integration";
 
     @Override
     public String getID() {


### PR DESCRIPTION
As the title says.

This is achieved by a `ArmorBaubleBehavior` which extends `BaubleBehavior` from base ceu, redirecting bauble method `onWornTick()` to `onArmorTick()`.
The armor won't render tho.

This has been tested in a dev environment.