### PR TITLE
Stop drop pad spawning for creative players

### DIFF
--- a/src/main/java/supersymmetry/common/EventHandlers.java
+++ b/src/main/java/supersymmetry/common/EventHandlers.java
@@ -53,6 +53,8 @@ public class EventHandlers {
     @SubscribeEvent
     public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
 
+        if (event.player.isCreative()) return;
+
         NBTTagCompound playerData = event.player.getEntityData();
         NBTTagCompound data = playerData.hasKey(EntityPlayer.PERSISTED_NBT_TAG) ? playerData.getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG) : new NBTTagCompound();
 


### PR DESCRIPTION
As the title says.

This has been tested in a dev environment.