### PR TITLE
Better handling bdsandm drum rotation & Fix susy modules

### DIFF
--- a/src/main/java/supersymmetry/common/CommonProxy.java
+++ b/src/main/java/supersymmetry/common/CommonProxy.java
@@ -1,11 +1,13 @@
 package supersymmetry.common;
 
 import gregtech.api.block.VariantItemBlock;
+import gregtech.api.modules.ModuleContainerRegistryEvent;
 import gregtech.api.unification.material.event.MaterialEvent;
 import gregtech.api.unification.material.event.PostMaterialEvent;
 import gregtech.client.utils.TooltipHelper;
 import gregtech.common.blocks.BlockWireCoil;
 import gregtech.common.items.MetaItems;
+import gregtech.modules.ModuleManager;
 import net.minecraft.block.Block;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.monster.EntityZombie;
@@ -38,6 +40,7 @@ import supersymmetry.common.materials.SusyMaterials;
 import supersymmetry.loaders.SuSyWorldLoader;
 import supersymmetry.loaders.SusyOreDictionaryLoader;
 import supersymmetry.loaders.recipes.SuSyRecipeLoader;
+import supersymmetry.modules.SuSyModules;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -171,6 +174,12 @@ public class CommonProxy {
         SuSyMetaBlocks.registerOreDict();
         SuSyRecipeLoader.init();
     }
+
+    @SubscribeEvent
+    public static void registerModuleContainer(ModuleContainerRegistryEvent event) {
+        ModuleManager.getInstance().registerContainer(new SuSyModules());
+    }
+
 
     private static <T extends Block> ItemBlock createItemBlock(T block, Function<T, ItemBlock> producer) {
         ItemBlock itemBlock = producer.apply(block);

--- a/src/main/java/supersymmetry/integration/baubles/BaublesModule.java
+++ b/src/main/java/supersymmetry/integration/baubles/BaublesModule.java
@@ -1,15 +1,17 @@
-package supersymmetry.integration.bubbles;
+package supersymmetry.integration.baubles;
 
 import baubles.api.BaubleType;
-import gregtech.api.GTValues;
 import gregtech.api.modules.GregTechModule;
 import gregtech.common.items.MetaItems;
 import gregtech.integration.IntegrationSubmodule;
 import net.minecraft.item.Item;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.jetbrains.annotations.NotNull;
+import supersymmetry.Supersymmetry;
+import supersymmetry.api.SusyLog;
 import supersymmetry.common.item.behavior.ArmorBaubleBehavior;
 import supersymmetry.modules.SuSyModules;
 
@@ -17,11 +19,11 @@ import java.util.Collections;
 import java.util.List;
 
 @GregTechModule(
-        moduleID = SuSyModules.MODULE_BUBBLES,
-        containerID = GTValues.MODID,
+        moduleID = SuSyModules.MODULE_BAUBLES,
+        containerID = Supersymmetry.MODID,
         modDependencies = "baubles",
         name = "SuSy Baubles Integration",
-        description = "Baubles Integration Module")
+        description = "SuSy Baubles Integration Module")
 public class BaublesModule extends IntegrationSubmodule {
 
     @SubscribeEvent(priority = EventPriority.LOW)
@@ -35,5 +37,10 @@ public class BaublesModule extends IntegrationSubmodule {
     @Override
     public List<Class<?>> getEventBusSubscribers() {
         return Collections.singletonList(BaublesModule.class);
+    }
+
+    @Override
+    public void init(FMLInitializationEvent event) {
+        SusyLog.logger.info("Baubles found. Enabling integration...");
     }
 }

--- a/src/main/java/supersymmetry/integration/bdsandm/BDSAndMModule.java
+++ b/src/main/java/supersymmetry/integration/bdsandm/BDSAndMModule.java
@@ -1,7 +1,6 @@
 package supersymmetry.integration.bdsandm;
 
 import funwayguy.bdsandm.core.BDSM;
-import gregtech.api.GTValues;
 import gregtech.api.cover.CoverRayTracer;
 import gregtech.api.modules.GregTechModule;
 import gregtech.common.items.tool.rotation.CustomBlockRotations;
@@ -10,11 +9,13 @@ import gregtech.integration.IntegrationSubmodule;
 import net.minecraft.block.BlockDirectional;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import supersymmetry.Supersymmetry;
+import supersymmetry.api.SusyLog;
 import supersymmetry.modules.SuSyModules;
 
 @GregTechModule(
         moduleID = SuSyModules.MODULE_BDSAndM,
-        containerID = GTValues.MODID,
+        containerID = Supersymmetry.MODID,
         modDependencies = "bdsandm",
         name = "SuSy BDSAndM Integration",
         description = "BDSAndM Integration Module")
@@ -33,7 +34,7 @@ public class BDSAndMModule extends IntegrationSubmodule {
 
     @Override
     public void init(FMLInitializationEvent event) {
-        getLogger().info("BDSAndM found. Enabling integration...");
+        SusyLog.logger.info("BDSAndM found. Enabling integration...");
         CustomBlockRotations.registerCustomRotation(BDSM.blockMetalBarrel, BDSAndM_BARREL_BEHAVIOR);
         CustomBlockRotations.registerCustomRotation(BDSM.blockWoodBarrel, BDSAndM_BARREL_BEHAVIOR);
     }

--- a/src/main/java/supersymmetry/integration/bdsandm/BDSAndMModule.java
+++ b/src/main/java/supersymmetry/integration/bdsandm/BDSAndMModule.java
@@ -1,6 +1,5 @@
 package supersymmetry.integration.bdsandm;
 
-import funwayguy.bdsandm.blocks.tiles.TileEntityBarrel;
 import funwayguy.bdsandm.core.BDSM;
 import gregtech.api.GTValues;
 import gregtech.api.cover.CoverRayTracer;
@@ -9,12 +8,9 @@ import gregtech.common.items.tool.rotation.CustomBlockRotations;
 import gregtech.common.items.tool.rotation.ICustomRotationBehavior;
 import gregtech.integration.IntegrationSubmodule;
 import net.minecraft.block.BlockDirectional;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import supersymmetry.modules.SuSyModules;
-
-import java.util.Objects;
 
 @GregTechModule(
         moduleID = SuSyModules.MODULE_BDSAndM,
@@ -29,14 +25,8 @@ public class BDSAndMModule extends IntegrationSubmodule {
         if (gridSide == null) return false;
         gridSide = gridSide.getOpposite(); // IDK what's happening here, blame the original author
         if (gridSide != state.getValue(BlockDirectional.FACING)) {
-            TileEntityBarrel barrel = ((TileEntityBarrel) world.getTileEntity(pos));
-            if (barrel != null) {
-                state = state.withProperty(BlockDirectional.FACING, gridSide);
-                NBTTagCompound tagCompound = barrel.writeToNBT(new NBTTagCompound());
-                world.setBlockState(pos, state);
-                Objects.requireNonNull(world.getTileEntity(pos)).readFromNBT(tagCompound);
-                return true;
-            }
+            world.setBlockState(pos, state.withProperty(BlockDirectional.FACING, gridSide));
+            return true;
         }
         return false;
     };

--- a/src/main/java/supersymmetry/mixins/bdsandm/TileEntityBarrelMixin.java
+++ b/src/main/java/supersymmetry/mixins/bdsandm/TileEntityBarrelMixin.java
@@ -1,0 +1,18 @@
+package supersymmetry.mixins.bdsandm;
+
+import funwayguy.bdsandm.blocks.tiles.TileEntityBarrel;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(TileEntityBarrel.class)
+public abstract class TileEntityBarrelMixin extends TileEntity {
+
+    @Override
+    public boolean shouldRefresh(@NotNull World world, @NotNull BlockPos pos, @NotNull IBlockState oldState, @NotNull IBlockState newSate) {
+        return oldState.getBlock() != newSate.getBlock();
+    }
+}

--- a/src/main/java/supersymmetry/modules/SuSyCoreModule.java
+++ b/src/main/java/supersymmetry/modules/SuSyCoreModule.java
@@ -1,0 +1,22 @@
+package supersymmetry.modules;
+
+import gregtech.api.modules.GregTechModule;
+import gregtech.api.modules.IGregTechModule;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import supersymmetry.Supersymmetry;
+import supersymmetry.api.SusyLog;
+
+@GregTechModule(
+        moduleID = SuSyModules.MODULE_CORE,
+        containerID = Supersymmetry.MODID,
+        name = "SuSy Core",
+        description = "Core module of SuSy Core, so this should call SuSy Core Core ngl.",
+        coreModule = true)
+public class SuSyCoreModule implements IGregTechModule {
+
+    @Override
+    public @NotNull Logger getLogger() {
+        return SusyLog.logger;
+    }
+}

--- a/src/main/java/supersymmetry/modules/SuSyModules.java
+++ b/src/main/java/supersymmetry/modules/SuSyModules.java
@@ -1,12 +1,15 @@
 package supersymmetry.modules;
 
 import gregtech.api.modules.IModuleContainer;
+import gregtech.api.modules.ModuleContainer;
 import supersymmetry.Supersymmetry;
 
+@ModuleContainer
 public class SuSyModules implements IModuleContainer {
 
+    public static final String MODULE_CORE = "susy_core";
     public static final String MODULE_BDSAndM = "bdsandm_integration";
-    public static final String MODULE_BUBBLES = "baubles_integration";
+    public static final String MODULE_BAUBLES = "baubles_integration";
 
     @Override
     public String getID() {

--- a/src/main/resources/mixins.susy.bdsandm.json
+++ b/src/main/resources/mixins.susy.bdsandm.json
@@ -6,6 +6,7 @@
   "compatibilityLevel" : "JAVA_8",
   "mixins" : [
     "BlockBarrelBaseMixin",
-    "ItemBarrelMixin"
+    "ItemBarrelMixin",
+    "TileEntityBarrelMixin"
   ]
 }


### PR DESCRIPTION
This is done by using a mixin overriding `shouldRefresh` in bdsandm barrel tileentity class
probably better than previous NBT copy-pasting method.

this also fixes the modules not working properly