### PR TITLE
Primitive Smelter polishments

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/primitive/MetaTileEntityPrimitiveSmelter.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/primitive/MetaTileEntityPrimitiveSmelter.java
@@ -48,10 +48,6 @@ public class MetaTileEntityPrimitiveSmelter extends RecipeMapPrimitiveMultiblock
         super(metaTileEntityId, SuSyRecipeMaps.PRIMITIVE_SMELTER);
     }
 
-    public static TraceabilityPredicate casingPredicate() {
-        return states(ModuleCore.Blocks.MASONRY_BRICK.getDefaultState());
-    }
-
     @Override
     protected void initializeAbilities() {
         this.importItems = new ItemHandlerList(getAbilities(SuSyMultiblockAbilities.PRIMITIVE_IMPORT_ITEMS));
@@ -64,17 +60,23 @@ public class MetaTileEntityPrimitiveSmelter extends RecipeMapPrimitiveMultiblock
         this.initializeAbilities();
     }
 
+    public static IBlockState getCasingState() {
+        return ModuleCore.Blocks.MASONRY_BRICK.getDefaultState();
+    }
+
     @Override
     protected @NotNull BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start()
-                .aisle("OOO", "III", "SIS")
-                .aisle("OOO", "I I", "I I")
-                .aisle("OOO", "ICI", "SIS")
-                .where('I', casingPredicate().or(abilities(SuSyMultiblockAbilities.PRIMITIVE_IMPORT_ITEMS).setMaxGlobalLimited(4)))
+                .aisle("BBB", "BBB", "SBS")
+                .aisle("BBB", "B#B", "B B")
+                .aisle("BBB", "BCB", "SBS")
+                .where('B', states(getCasingState()).setMinGlobalLimited(14)
+                        .or(abilities(SuSyMultiblockAbilities.PRIMITIVE_IMPORT_ITEMS).setPreviewCount(1))
+                        .or(abilities(SuSyMultiblockAbilities.PRIMITIVE_EXPORT_ITEMS).setPreviewCount(1)))
                 .where('C', selfPredicate())
-                .where('O', casingPredicate().or(abilities(SuSyMultiblockAbilities.PRIMITIVE_EXPORT_ITEMS).setMaxGlobalLimited(2)))
                 .where('S', states(ModuleCore.Blocks.MASONRY_BRICK_SLAB.getDefaultState()))
-                .where(' ', air().or(SNOW_PREDICATE))
+                .where('#', air().or(SNOW_PREDICATE))
+                .where(' ', air())
                 .build();
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multiblockpart/MetaTileEntityPrimitiveItemBus.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multiblockpart/MetaTileEntityPrimitiveItemBus.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class MetaTileEntityPrimitiveItemBus extends MetaTileEntityItemBus {
 
     public MetaTileEntityPrimitiveItemBus(ResourceLocation metaTileEntityId, boolean isExportHatch) {
-        super(metaTileEntityId, 0, isExportHatch);
+        super(metaTileEntityId, 1, isExportHatch);
         initializeInventory();
     }
 

--- a/src/main/java/supersymmetry/common/metatileentities/multiblockpart/MetaTileEntityPrimitiveItemBus.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multiblockpart/MetaTileEntityPrimitiveItemBus.java
@@ -1,5 +1,7 @@
 package supersymmetry.common.metatileentities.multiblockpart;
 
+import gregtech.api.capability.impl.NotifiableItemStackHandler;
+import gregtech.api.items.itemhandlers.GTItemStackHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
@@ -52,5 +54,27 @@ public class MetaTileEntityPrimitiveItemBus extends MetaTileEntityItemBus {
     @Override
     public String getHarvestTool() {
         return "pickaxe";
+    }
+
+    @Override
+    protected IItemHandlerModifiable createExportItemHandler() {
+        return !isExportHatch ? new GTItemStackHandler(this, 0) :
+                new NotifiableItemStackHandler(this, 4, getController(), true) {
+                    @Override
+                    public int getSlotLimit(int slot) {
+                        return 16;
+                    }
+                };
+    }
+
+    @Override
+    protected IItemHandlerModifiable createImportItemHandler() {
+        return isExportHatch ? new GTItemStackHandler(this, 0) :
+                new NotifiableItemStackHandler(this, 4, getController(), false) {
+                    @Override
+                    public int getSlotLimit(int slot) {
+                        return 16;
+                    }
+                };
     }
 }


### PR DESCRIPTION
This PR:
- makes Primitive Smelter to have non-strict bus placement requirement (i.e. import/export buses can now be put anywhere rather than specific layers).
- makes that Primitive Buses have 4 slots, but each slot now can only hold 16 items in it. So players don't need to put too many buses on a primitive smelter if they just want to operate it manually.
- limit minimum casing counts instead of buses.

This have been tested in a dev environment. 