### PR TITLE
Patch Traveler's Backpack

### DIFF
--- a/src/main/java/supersymmetry/mixins/travelersbackpack/TileEntityTravelersBackpackMixin.java
+++ b/src/main/java/supersymmetry/mixins/travelersbackpack/TileEntityTravelersBackpackMixin.java
@@ -1,0 +1,18 @@
+package supersymmetry.mixins.travelersbackpack;
+
+import com.tiviacz.travelersbackpack.tileentity.TileEntityTravelersBackpack;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(TileEntityTravelersBackpack.class)
+public abstract class TileEntityTravelersBackpackMixin extends TileEntity {
+
+    @Override
+    public boolean shouldRefresh(@NotNull World world, @NotNull BlockPos pos, @NotNull IBlockState oldState, @NotNull IBlockState newSate) {
+        return oldState.getBlock() != newSate.getBlock();
+    }
+}

--- a/src/main/resources/mixins.susy.travelersbackpack.json
+++ b/src/main/resources/mixins.susy.travelersbackpack.json
@@ -6,5 +6,8 @@
   "compatibilityLevel": "JAVA_8",
   "client": [
     "GuiTravelersBackpackMixin"
+  ],
+  "mixins" : [
+    "TileEntityTravelersBackpackMixin"
   ]
 }


### PR DESCRIPTION
Just like what we did for bdsandmore barrels/crates, stopping wrench rotation from voiding all datas stored in the TileEntity,
fixes [this](https://discord.com/channels/881234100504109166/1334010994653139004)
tested in dev environment

note: this is a temporary solution. Wait for either UT or Fixeroo to include a more universal implementation.