### PR TITLE
Redirects `getEntitiesWithinAABB` calls in `EntityAnimation` class

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -75,5 +75,8 @@ dependencies {
 
     compileOnly rfg.deobf("curse.maven:yungs-better-mineshafts-forge-389665:3247154")
 
+    implementation rfg.deobf("curse.maven:littletiles-257818:5180387")
+    implementation rfg.deobf("curse.maven:creativecore-257814:4722163")
+
     api("CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.700")
 }

--- a/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
+++ b/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
@@ -9,7 +9,17 @@ import java.util.stream.Collectors;
 
 public class SuSyLateMixinLoader implements ILateMixinLoader {
 
-    public static final List<String> modMixins = ImmutableList.of("bdsandm", "gregtech", "mcjtylib_ng", "xnet", "travelersbackpack", "yungs", "reccomplex", "fluidlogged_api");
+    public static final List<String> modMixins = ImmutableList.of(
+            "bdsandm",
+            "gregtech",
+            "mcjtylib_ng",
+            "xnet",
+            "travelersbackpack",
+            "yungs",
+            "reccomplex",
+            "fluidlogged_api",
+            "littletiles"
+    );
 
     @Override
     public List<String> getMixinConfigs() {

--- a/src/main/java/supersymmetry/mixins/littletiles/EntityAnimationMixin.java
+++ b/src/main/java/supersymmetry/mixins/littletiles/EntityAnimationMixin.java
@@ -1,0 +1,45 @@
+package supersymmetry.mixins.littletiles;
+
+import com.creativemd.littletiles.common.entity.EntityAnimation;
+import com.google.common.base.Predicate;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Stop {@link World#getEntitiesWithinAABB(Class, AxisAlignedBB, Predicate)} calls in {@link EntityAnimation}.
+ * A brute-force solution for it being too laggy sometimes when the entity is not properly unloaded.
+ */
+@Mixin(value = EntityAnimation.class, remap = false)
+public class EntityAnimationMixin {
+
+    @Redirect(method = "moveAndRotateAnimation(Lcom/creativemd/creativecore/common/utils/math/collision/CollisionCoordinator;)V",
+              at = @At(value = "INVOKE",
+                       target = "Lnet/minecraft/world/World;getEntitiesWithinAABB(Ljava/lang/Class;Lnet/minecraft/util/math/AxisAlignedBB;Lcom/google/common/base/Predicate;)Ljava/util/List;",
+                       remap = true))
+    public List<Entity> iDoNotCare(World i, Class<?> do_, AxisAlignedBB not, Predicate<?> care) {
+        return Collections.emptyList();
+    }
+
+    @Redirect(method = "moveAndRotateAnimation(DDDDDD)V",
+              at = @At(value = "INVOKE",
+                       target = "Lnet/minecraft/world/World;getEntitiesWithinAABB(Ljava/lang/Class;Lnet/minecraft/util/math/AxisAlignedBB;Lcom/google/common/base/Predicate;)Ljava/util/List;",
+                       remap = true))
+    public List<Entity> iDoNotCareEither(World i, Class<?> do_, AxisAlignedBB not, Predicate<?> care) {
+        return Collections.emptyList();
+    }
+
+    @Redirect(method = "onTick",
+              at = @At(value = "INVOKE",
+                       target = "Lnet/minecraft/world/World;getEntitiesWithinAABB(Ljava/lang/Class;Lnet/minecraft/util/math/AxisAlignedBB;Lcom/google/common/base/Predicate;)Ljava/util/List;",
+                       remap = true))
+    public List<Entity> iDoNotCareAsWell(World i, Class<?> do_, AxisAlignedBB not, Predicate<?> care) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/mixins.susy.littletiles.json
+++ b/src/main/resources/mixins.susy.littletiles.json
@@ -1,0 +1,10 @@
+{
+  "package" : "supersymmetry.mixins.littletiles",
+  "refmap" : "mixins.susy.refmap.json",
+  "target" : "@env(DEFAULT)",
+  "minVersion" : "0.8",
+  "compatibilityLevel" : "JAVA_8",
+  "mixins" : [
+    "EntityAnimationMixin"
+  ]
+}


### PR DESCRIPTION
Reason:
https://spark.lucko.me/rRd5tU2Xr5
![image](https://github.com/user-attachments/assets/ae943430-9df0-4d83-b88d-949e1d9cf96c)

Needs testing.
