### PR TITLE
Drone pad snow problem patch

### DIFF
--- a/src/main/java/supersymmetry/common/entities/EntityDrone.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDrone.java
@@ -185,7 +185,7 @@ public class EntityDrone extends EntityLiving implements IAnimatable {
 
                 this.motionY += 0.125;
 
-                if(age >= 90 && this.isCollidingWithBlocks()) {
+                if (this.isCollidingWithBlocks()) {
                     this.explode();
                 }
 
@@ -223,8 +223,8 @@ public class EntityDrone extends EntityLiving implements IAnimatable {
     }
 
     public boolean isCollidingWithBlocks() {
-        return this.world.getBlockState(mutableBlockPos.setPos(this.posX, this.posY + 1, this.posZ)) != Blocks.AIR.getDefaultState()
-                || this.world.getBlockState(mutableBlockPos.setPos(this.posX, this.posY - 1, this.posZ)) != Blocks.AIR.getDefaultState();
+        return !(this.world.getBlockState(mutableBlockPos.setPos(this.posX, this.posY + 1, this.posZ)).getBlock().isPassable(world, mutableBlockPos)
+                 && this.world.getBlockState(mutableBlockPos.setPos(this.posX, this.posY - 1, this.posZ)).getBlock().isPassable(world, mutableBlockPos));
     }
 
     public boolean reachedSky() {

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityDronePad.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityDronePad.java
@@ -55,13 +55,12 @@ public class MetaTileEntityDronePad extends RecipeMapMultiblockController {
     @Override
     protected BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start()
-                .aisle(" CCC ", "     ", "     ")
-                .aisle("CPPPC", " AAA ", " AAA ")
-                .aisle("CPPPC", " AAA ", " AAA ")
-                .aisle("CPPPC", " AAA ", " AAA ")
-                .aisle(" CSC ", "     ", "     ")
+                .aisle(" CCC ")
+                .aisle("CPPPC")
+                .aisle("CPPPC")
+                .aisle("CPPPC")
+                .aisle(" CSC ")
                 .where(' ', any())
-                .where('A', air())
                 .where('S', selfPredicate())
                 .where('C', states(getCasingState()).setMinGlobalLimited(6)
                         .or(autoAbilities(true, false, true, true, false, false, false)))


### PR DESCRIPTION
# WHAT IS WRONG?
#386
So because the of the multiblock checks for 2 bocks above the pads block, when snow or any block beside air are present the multiblock unform and if any recipe is running it will be cancel and the drone is sent to the backroom.

# WHAT THIS PR CHANGED
- Change the drone collision check behavior:
   - From exploding when hitting anything but air to only explode when hit SOLID blocks aka blocks that have a collision shape (full block, fence, stair, cobweb, etc..) so 1 layer snow (that generated from winter or player placed), string, grass won't cause the drone to explode.
   - Remove the delayed age check so the drone will check for collision as soon as it start flying. This is to ensure the drone will explode if there is block right above the pad.
 - Remove air block check for the drone pad multiblock: With the check removed the drone pad multiblock wont unform when anything like snow layer forms above it which causes this issue to begin with. If the drone explode its because the player was unable to clear the way.

# ADDITIONAL INFO
I'm TCSlender in the susy discord if more info needed