### PR TITLE
Hot Fix drone exploding during take off

### DIFF
--- a/src/main/java/supersymmetry/common/entities/EntityDrone.java
+++ b/src/main/java/supersymmetry/common/entities/EntityDrone.java
@@ -185,7 +185,7 @@ public class EntityDrone extends EntityLiving implements IAnimatable {
 
                 this.motionY += 0.125;
 
-                if (this.isCollidingWithBlocks()) {
+                if (age >= 63 && this.isCollidingWithBlocks()) {
                     this.explode();
                 }
 


### PR DESCRIPTION
# WHAT IS WRONG?
when i remove the age check i didn't realized that the velocity is only added after age>=55, so when it start checking for collision it hasn't taken off yet so it explodes

# WHAT THIS PR CHANGED
Add the age check back but tuned to check for collision after it has flown up a block.

# TEST CASES
- normal operation

https://github.com/user-attachments/assets/1a496047-c72d-4074-8d8d-e7f072cd360b

- one block in the way

https://github.com/user-attachments/assets/9341cbf7-e08c-488d-ab5c-4ccfb305e140

- 1 layer snow

https://github.com/user-attachments/assets/41e791c9-e9ed-41ff-8d66-acb5590c8b07

- 1> above

https://github.com/user-attachments/assets/e006d503-24af-4d5e-aa94-c64fd42bae17

# ADDITIONAL INFO
I'm TCSlender in the susy discord if more info needed


