### PR TITLE
Fix Evap Pool

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
@@ -679,7 +679,7 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
         rollingAverage[tickTimer % 20] = 0; // reset rolling average for this tick index
 
         //should skip/cost an extra tick the first time and then anywhere from 1-9 extra when rolling over. Determines exposedblocks
-        if (tickTimer % 10 == 0 && tickTimer != 0) {
+        if (tickTimer % 4 == 0 && tickTimer != 0) {
             //no sunlight heat generated when raining or during night. May be incongruent with partial exposure to sun, but oh well
             if (getWorld().isRainingAt(getPos().offset(getFrontFacing().getOpposite(), 2)) || !getWorld().isDaytime()) {
                 exposedBlocks = 0;
@@ -688,8 +688,8 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
             //checks for ow and skylight access to prevent beneath portal issues (-1 = the Nether, 0 = normal world)
             else if (getWorld().provider.getDimension() == 0) {
                 //tickTimer is always multiple of 20 at this point, so division by 20 yields proper counter. You can treat (tickTimer/20) as 'i'
-                int row = ((tickTimer / 20) / columnCount) % rowCount; //going left to right, further to closer checking skylight access.
-                int col = ((tickTimer / 20) % columnCount);
+                int row = ((tickTimer / 4) / columnCount) % rowCount; //going left to right, further to closer checking skylight access.
+                int col = ((tickTimer / 4) % columnCount);
                 //places blockpos for skycheck into correct position. Row counts from furthest to closest (kinda inconsistent but oh well)
                 BlockPos.MutableBlockPos skyCheckPos = new BlockPos.MutableBlockPos(getPos().offset(EnumFacing.UP, 2));
                 skyCheckPos.move(getFrontFacing().getOpposite(), rowCount - row + 1);
@@ -705,7 +705,7 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
                 //Perform skylight check
                 if (!getWorld().canBlockSeeSky(skyCheckPos)) {
                     //only decrement exposedBlocks if previously exposed block is found to no longer be exposed and one full pass has occurred
-                    if (wasExposed[(row * columnCount) + col] != 0 && tickTimer / 20 > rowCount * columnCount) {
+                    if (wasExposed[(row * columnCount) + col] != 0 && tickTimer / 2 > rowCount * columnCount) {
                         exposedBlocks = Math.max(0, exposedBlocks - 1);
                         wasExposed[(row * columnCount) + col] = 0;
                     }

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
@@ -673,7 +673,7 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
         // setCoilActivity(false); // solves world issue reload where coils would be active even if multi was not running
         if (structurePattern.getError() != null) return; //dont do processing for unformed multis
 
-        //ensure timer is non-negative by anding sign bit with 0
+        //ensure timer is non-negative by ending sign bit with 0
         tickTimer = tickTimer & 0b01111111111111111111111111111111;
         checkCoilActivity(); // make coils active if they should be
         rollingAverage[tickTimer % 20] = 0; // reset rolling average for this tick index
@@ -947,13 +947,13 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
 
     public int getRollingAverageJt() {
         // sunlight => 1kJ/s/m^2 -> 50J/t/m^2
-        return exposedBlocks * 50 + Arrays.stream(rollingAverage).sum() / 20;
+        return Arrays.stream(rollingAverage).sum() / 20;
     }
 
     public float getAverageRecipeSpeed() {
         if (!recipeMapWorkable.isActive() || recipeMapWorkable.getPreviousRecipe() == null) return 0;
         float recipeJt = recipeMapWorkable.getPreviousRecipe().getProperty(EvaporationEnergyProperty.getInstance(), -1);
-        return (exposedBlocks * 50 + Arrays.stream(rollingAverage).sum() / 20F) / recipeJt;
+        return (Arrays.stream(rollingAverage).sum() / 20F) / recipeJt;
     }
 
     public String getAverageRecipeSpeedString() {


### PR DESCRIPTION
This PR fixes the Average Energy In and Average Speed lines in the GUI of the Evap Pool.
Explanation: rollingAverage already takes account of exposedBlocks 
as rollingAverage = joules in line 1028, and inputEnergy accepts exposedBlocks * 50 (line 723) as joules (line 1015)


Also, Exposed Block searching speed  has increased fivefold.