### PR TITLE
fix condenser + various other Multiblocks

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCondenser.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityCondenser.java
@@ -3,6 +3,7 @@ package supersymmetry.common.metatileentities.multi.electric;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
@@ -35,7 +36,8 @@ public class MetaTileEntityCondenser extends RecipeMapMultiblockController {
                 .aisle("CCC", "CSC", "CCC", "CCC")
                 .where('S', selfPredicate())
                 .where('C', states(MetaBlocks.METAL_CASING.getState(MetalCasingType.ALUMINIUM_FROSTPROOF)).setMinGlobalLimited(27)
-                        .or(autoAbilities(true, true, false, false, true, true, false)))
+                        .or(autoAbilities(false, true, false, false, true, true, false))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(0).setMaxGlobalLimited(2)))
                 .where(' ', air())
                 .build();
     }

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
@@ -673,7 +673,7 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
         // setCoilActivity(false); // solves world issue reload where coils would be active even if multi was not running
         if (structurePattern.getError() != null) return; //dont do processing for unformed multis
 
-        //ensure timer is non-negative by ending sign bit with 0
+        //ensure timer is non-negative by anding sign bit with 0
         tickTimer = tickTimer & 0b01111111111111111111111111111111;
         checkCoilActivity(); // make coils active if they should be
         rollingAverage[tickTimer % 20] = 0; // reset rolling average for this tick index

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighPressureCryogenicDistillationPlant.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighPressureCryogenicDistillationPlant.java
@@ -46,7 +46,7 @@ public class MetaTileEntityHighPressureCryogenicDistillationPlant extends MetaTi
                 .aisle("DDD", "DDD", "DDD")
                 .where('S', this.selfPredicate())
                 .where('C', states(getCasingState())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1))
                         .or(autoAbilities(true, false).setExactLimit(1)))
                 .where('F', states(SuSyBlocks.MULTIBLOCK_CASING.getState(BlockSuSyMultiblockCasing.CasingType.SIEVE_TRAY)))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighTemperatureDistillationTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHighTemperatureDistillationTower.java
@@ -42,7 +42,7 @@ public class MetaTileEntityHighTemperatureDistillationTower extends MetaTileEnti
                 .where('S', selfPredicate())
                 .where('Y', states(getCasingState())
                         .or(abilities(MultiblockAbility.EXPORT_ITEMS).setMaxGlobalLimited(1))
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMaxGlobalLimited(1))
                         .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1)))
                 .where('X', states(getCasingState())

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityLowPressureCryogenicDistillationPlant.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityLowPressureCryogenicDistillationPlant.java
@@ -60,7 +60,7 @@ public class MetaTileEntityLowPressureCryogenicDistillationPlant extends MetaTil
                 .aisle("DDD", "DDD", "DDD")
                 .where('S', this.selfPredicate())
                 .where('C', states(getCasingState())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1))
                         .or(autoAbilities(true, false).setExactLimit(1)))
                 .where('F', states(SuSyBlocks.MULTIBLOCK_CASING.getState(BlockSuSyMultiblockCasing.CasingType.STRUCTURAL_PACKING)))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityOreSorter.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityOreSorter.java
@@ -45,7 +45,7 @@ public class MetaTileEntityOreSorter extends RecipeMapMultiblockController {
                         .or(autoAbilities(true, true, true, true, false, false, false)))
                 .where('C', states(new IBlockState[]{MetaBlocks.BOILER_CASING.getState(BoilerCasingType.STEEL_PIPE)})
                         .or(autoAbilities(false, false, false, false, true, true, false)))
-                .where('D', states(new IBlockState[]{MetaBlocks.FRAMES.get(Materials.Aluminium).getBlock(Materials.Aluminium)}))
+                .where('D', frames(Materials.Aluminium))
                 .where(' ', any())
                 .where('#', air())
                 .build();

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPreciseMillingMachine.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPreciseMillingMachine.java
@@ -50,7 +50,7 @@ public class MetaTileEntityPreciseMillingMachine extends RecipeMapMultiblockCont
                 .where('S', selfPredicate())
                 .where('B', states(getBaseCasingState()).setMinGlobalLimited(18)
                         .or(abilities(MultiblockAbility.INPUT_ENERGY)
-                                .setMinGlobalLimited(1).setMaxGlobalLimited(3)
+                                .setMinGlobalLimited(1).setMaxGlobalLimited(2)
                                 .addTooltip("gregtech.multiblock.pattern.error.milling.lower"))
                         .or(abilities(MultiblockAbility.MAINTENANCE_HATCH)
                                 .setExactLimit(1)

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySieveDistillationTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySieveDistillationTower.java
@@ -70,7 +70,7 @@ public class MetaTileEntitySieveDistillationTower extends MetaTileEntityOrderedD
                 .where('S', selfPredicate())
                 .where('Y', states(getCasingState())
                         .or(abilities(MultiblockAbility.EXPORT_ITEMS).setMaxGlobalLimited(1))
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1).setMaxGlobalLimited(2)))
                 .where('X', states(getCasingState())
                         .or(metaTileEntities(MultiblockAbility.REGISTRY.get(MultiblockAbility.EXPORT_FLUIDS).stream()

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySingleColumnCryogenicDistillationPlant.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySingleColumnCryogenicDistillationPlant.java
@@ -52,7 +52,7 @@ public class MetaTileEntitySingleColumnCryogenicDistillationPlant extends MetaTi
                 .aisle("DDD", "DED", "DDD")
                 .where('S', this.selfPredicate())
                 .where('C', states(getCasingState())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1))
                         .or(autoAbilities(false, true, false, false, false, false, false).setExactLimit(1)))
                 .where('F', states(SuSyBlocks.MULTIBLOCK_CASING.getState(BlockSuSyMultiblockCasing.CasingType.STRUCTURAL_PACKING)))

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityVacuumDistillationTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityVacuumDistillationTower.java
@@ -66,7 +66,7 @@ public class MetaTileEntityVacuumDistillationTower extends MetaTileEntityOrdered
                 .where('P', states(getPipeCasingState()))
                 .where('F', frames(Materials.Steel))
                 .where('C', states(getCasingState())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1)))
                 .where('I', abilities(MultiblockAbility.EXPORT_ITEMS).setMaxGlobalLimited(1))


### PR DESCRIPTION
Condenser should be able to form with 0 energy hatch now.
Max Energy hatch requirements for many multiblocks have been reduced from 3 to 2, because GTCEu multiblocks can't really utilize >2 energy hatch.
Fixed the comment on EvapPool.