### PR TITLE
Fix incinerator ignoring remaining items in inventory

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/single/electric/MetaTileEntityIncinerator.java
+++ b/src/main/java/supersymmetry/common/metatileentities/single/electric/MetaTileEntityIncinerator.java
@@ -106,7 +106,13 @@ public class MetaTileEntityIncinerator extends TieredMetaTileEntity implements I
                     setCanProgress(true);
                 progress++;
                 if (progress >= maxProgress) {
-                    this.importItems.extractItem(startSlot, itemsPerRun, false);
+                    int remainingVoids = itemsPerRun;
+                    while (remainingVoids > 0) {
+                        remainingVoids -= this.importItems.extractItem(startSlot, remainingVoids, false).getCount();
+                        startSlot = GTFOUtils.getFirstUnemptyItemSlot(this.importItems, 0);
+                        if (startSlot == -1)
+                            break;
+                    }
                     progress = 0;
                 }
             } else {


### PR DESCRIPTION
I noticed the incinerator ignores items in remaining slots if it has less than the max # items it can void in the first slot, effectively rendering any slot other than the first one useless. If you, for example, have 3 items in the first slot and a full stack in the second, you'd expect it to void the entire first slot and then 7 items from the second slot. 

I have implemented this to work accordingly, and have verified it to work correctly.