### PR TITLE
feat: halve all wire loss

### DIFF
--- a/src/main/java/supersymmetry/mixins/gregtech/EnergyRoutePathMixin.java
+++ b/src/main/java/supersymmetry/mixins/gregtech/EnergyRoutePathMixin.java
@@ -1,0 +1,22 @@
+package supersymmetry.mixins.gregtech;
+
+import gregtech.common.pipelike.cable.net.EnergyRoutePath;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EnergyRoutePath.class)
+public class EnergyRoutePathMixin {
+    @Shadow(remap = false)
+    private long maxLoss;
+    /**
+     * Returns the loss of the energy route.
+     * @author Bruberu
+     * @reason This really shouldn't be overwritten anywhere else, and also this is very particular to this pack's balancing.
+     * @return The loss of the energy route
+     */
+    @Overwrite(remap = false)
+    public long getMaxLoss() {
+        return maxLoss / 2;
+    }
+}

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -1030,3 +1030,6 @@ tile.hardened_blocks.kryp8.name=Hardened Kryp 8
 #Custom Sheets
 tile.custom_sheets.darkwhitemetalsheet.name=Darker White Metal Sheet
 tile.custom_sheets.lightergraymetalsheet.name=Lighter Gray Metal Sheet
+
+# Overrides
+gregtech.cable.loss_per_block=§cLoss/Meter/Ampere: §f%,d§f EU-Volt §cper §c2 meters

--- a/src/main/resources/mixins.susy.gregtech.json
+++ b/src/main/resources/mixins.susy.gregtech.json
@@ -11,6 +11,7 @@
     "MetaTileEntityLargeMinerMixin",
     "MetaTileEntityMinerMixin",
     "MultiblockControllerBaseMixin",
-    "CommonProxyMixin"
+    "CommonProxyMixin",
+    "EnergyRoutePathMixin"
   ]
 }


### PR DESCRIPTION
Literally halves all wire loss. Also changes the formatting of the wire loss to say "per 2 meters."