### PR TITLE
fix: sheeted frame drops

### DIFF
--- a/src/main/java/supersymmetry/common/blocks/BlockSheetedFrame.java
+++ b/src/main/java/supersymmetry/common/blocks/BlockSheetedFrame.java
@@ -160,7 +160,7 @@ public class BlockSheetedFrame extends Block {
     }
 
     public int damageDropped(@Nonnull IBlockState state) {
-        return this.getMetaFromState(state);
+        return (this.getMetaFromState(state) & 0b0011) + 4;
     }
 
     @Nonnull


### PR DESCRIPTION
Makes sure that when a player breaks a rotated sheeted frame, they do not receive a frame that still contains the placed orientation.