### PR TITLE
Fix Lost Translation Keys

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityArcFurnaceComplex.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityArcFurnaceComplex.java
@@ -80,7 +80,7 @@ public class MetaTileEntityArcFurnaceComplex extends MetaTileEntityAdvancedArcFu
 
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
-        tooltip.add(I18n.format("gregtech.machine.parallel_pure", 256));
+        tooltip.add(I18n.format("susy.machine.parallel_pure", 256));
     }
 
     @Nonnull

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMetallurgicalConverter.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMetallurgicalConverter.java
@@ -106,7 +106,7 @@ public class MetaTileEntityMetallurgicalConverter extends RecipeMapMultiblockCon
 
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
-        tooltip.add(I18n.format("gregtech.machine.parallel_pure", 64));
+        tooltip.add(I18n.format("susy.machine.parallel_pure", 64));
     }
 
     private class MetallurgicalConverterLogic extends MultiblockRecipeLogic {

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/strand/MetaTileEntityStrandShaper.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/strand/MetaTileEntityStrandShaper.java
@@ -248,18 +248,18 @@ public abstract class MetaTileEntityStrandShaper extends MultiblockWithDisplayBa
                             comps.add(new TextComponentTranslation("susy.multiblock.strand_casting.no_strand"));
                             return;
                         }
-                        comps.add(new TextComponentTranslation("gregtech.multiblock.strand_casting.output_detected"));
+                        comps.add(new TextComponentTranslation("susy.multiblock.strand_casting.output_detected"));
                         displayStrand = output.getStrand();
                     }
-                    comps.add(new TextComponentTranslation("gregtech.multiblock.strand_casting.thickness", String.format("%.2f", displayStrand.thickness)));
-                    comps.add(new TextComponentTranslation("gregtech.multiblock.strand_casting.width", String.format("%.2f", displayStrand.width)));
+                    comps.add(new TextComponentTranslation("susy.multiblock.strand_casting.thickness", String.format("%.2f", displayStrand.thickness)));
+                    comps.add(new TextComponentTranslation("susy.multiblock.strand_casting.width", String.format("%.2f", displayStrand.width)));
 
                     StrandConversion conversion = StrandConversion.getConversion(displayStrand);
                     if (conversion == null) {
-                        comps.add(new TextComponentTranslation("gregtech.multiblock.strand_casting.no_conversion"));
+                        comps.add(new TextComponentTranslation("susy.multiblock.strand_casting.no_conversion"));
                         return;
                     }
-                    comps.add(new TextComponentTranslation("gregtech.multiblock.strand_casting.ore_prefix",
+                    comps.add(new TextComponentTranslation("susy.multiblock.strand_casting.ore_prefix",
                             new TextComponentTranslation("supersymmetry.prefix." + conversion.prefix.name.toLowerCase())));
                 });
     }

--- a/src/main/java/supersymmetry/common/metatileentities/single/electric/MetaTileEntityIncinerator.java
+++ b/src/main/java/supersymmetry/common/metatileentities/single/electric/MetaTileEntityIncinerator.java
@@ -284,6 +284,6 @@ public class MetaTileEntityIncinerator extends TieredMetaTileEntity implements I
         tooltip.add(I18n.format("gregtech.universal.tooltip.item_storage_capacity", getInventorySize()));
         tooltip.add(I18n.format("susy.machine.incinerator.tooltip.1", itemsPerRun, maxProgress));
         tooltip.add(I18n.format("susy.machine.incinerator.tooltip.2"));
-        tooltip.add(I18n.format("gregtech.machine.incinerator.tooltip.3"));
+        tooltip.add(I18n.format("susy.machine.incinerator.tooltip.3"));
     }
 }

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -291,6 +291,7 @@ susy.multiblock.evaporation_pool.exposed_blocks=Exposed Blocks: %s
 susy.multiblock.evaporation_pool.average_speed=Avg Speed: %sx
 susy.multiblock.pattern.error.coils_or_bed=§cAll heating coils or evaporation beds must be the same§r
 
+susy.top.energy_consumption=Energy Consumption:
 susy.multiblock.strand_casting.thickness=Thickness: %s
 susy.multiblock.strand_casting.width=Width: %s
 susy.multiblock.strand_casting.no_strand=No strand detected


### PR DESCRIPTION
Fixed some tooltip and strand casting translation keys that were not moved into the `susy` namespace.