### PR TITLE
fix: removes lwjgl

### DIFF
--- a/src/main/java/supersymmetry/api/stockinteraction/StockHelperFunctions.java
+++ b/src/main/java/supersymmetry/api/stockinteraction/StockHelperFunctions.java
@@ -4,13 +4,13 @@ import cam72cam.immersiverailroading.entity.EntityRollingStock;
 import cam72cam.immersiverailroading.items.ItemRollingStock;
 import cam72cam.mod.entity.ModdedEntity;
 import cam72cam.mod.item.ItemStack;
+import com.cleanroommc.modularui.utils.Vector3f;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
-import org.lwjgl.util.vector.Vector3f;
 
 import java.util.Comparator;
 import java.util.List;


### PR DESCRIPTION
Since LWJGL is a client-side-only package, we need to use a different class for Vector3f when calculating stock interactor bounding boxes. ModularUI's is fine.