### PR TITLE
Fix some GT lamps not rendering in the inventory when both VintageFix & CTM are installed

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -76,6 +76,7 @@ dependencies {
     compileOnly rfg.deobf('curse.maven:travelers-backpack-321117:3150850')
     compileOnly rfg.deobf('curse.maven:bubbles-a-baubles-fork-995393:5719448')
     compileOnly rfg.deobf('curse.maven:barrels-drums-storage-more-319404:2708193')
+    compileOnly rfg.deobf("curse.maven:vintagefix-871198:6609247")
 
     // # Optional dependencies. Uncomment the ones you need
 //    runtimeOnlyNonPublishable rfg.deobf('curse.maven:the-beneath-254629:3425551')

--- a/src/main/java/supersymmetry/integration/vintagefix/VintageFixModule.java
+++ b/src/main/java/supersymmetry/integration/vintagefix/VintageFixModule.java
@@ -1,0 +1,58 @@
+package supersymmetry.integration.vintagefix;
+
+import gregtech.api.modules.GregTechModule;
+import gregtech.integration.IntegrationSubmodule;
+import gregtech.integration.baubles.BaublesModule;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.embeddedt.vintagefix.dynamicresources.model.DynamicBakedModelProvider;
+import org.embeddedt.vintagefix.event.DynamicModelBakeEvent;
+import org.jetbrains.annotations.NotNull;
+import supersymmetry.Supersymmetry;
+import supersymmetry.mixins.vintagefix.LampBakedModelAccessor;
+import supersymmetry.mixins.vintagefix.LampBakedModelAccessor.EntryAccessor;
+import supersymmetry.mixins.vintagefix.LampBakedModelAccessor.KeyAccessor;
+import supersymmetry.modules.SuSyModules;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@GregTechModule(
+        moduleID = SuSyModules.MODULE_VINTAGEFIX,
+        containerID = Supersymmetry.MODID,
+        modDependencies = "vintagefix",
+        name = "SuSy VintageFix Integration",
+        description = "SuSy VintageFix Integration Module")
+public class VintageFixModule extends IntegrationSubmodule {
+
+    @NotNull
+    @Override
+    public List<Class<?>> getEventBusSubscribers() {
+        return Collections.singletonList(VintageFixModule.class);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public static void onDynModelBake(DynamicModelBakeEvent event) {
+        if(!(event.location instanceof ModelResourceLocation)) return;
+
+        for (Map.Entry<KeyAccessor, EntryAccessor> e : LampBakedModelAccessor.getEntries().entrySet()) {
+            var entry = e.getValue();
+            if (entry.getOriginalModel() == event.location) {
+                if (entry.getCustomItemModel() != null) {
+                    IBakedModel model = event.bakedModel;
+                    if (model != null) {
+                        // Directly provide existing model to prevent using CTM models
+                        IBakedModel customModel = e.getKey().getModelType().createModel(model);
+                        DynamicBakedModelProvider.instance.putObject(entry.getCustomItemModel(), customModel);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
+++ b/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
@@ -17,7 +17,8 @@ public class SuSyLateMixinLoader implements ILateMixinLoader {
             "xnet",
             "travelersbackpack",
             "reccomplex",
-            "fluidlogged_api"
+            "fluidlogged_api",
+            "vintagefix"
     );
 
     @Override

--- a/src/main/java/supersymmetry/mixins/vintagefix/LampBakedModelAccessor.java
+++ b/src/main/java/supersymmetry/mixins/vintagefix/LampBakedModelAccessor.java
@@ -1,0 +1,38 @@
+package supersymmetry.mixins.vintagefix;
+
+import gregtech.client.model.lamp.LampBakedModel;
+import gregtech.client.model.lamp.LampModelType;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.Map;
+
+@Mixin(value = LampBakedModel.class, remap = false)
+public interface LampBakedModelAccessor {
+
+    @Accessor("ENTRIES")
+    static Map<KeyAccessor, EntryAccessor> getEntries() {
+        throw new AssertionError("LampBakedModelAccessor is not applied!");
+    }
+
+    @Mixin(value = LampBakedModel.Entry.class, remap = false)
+    interface EntryAccessor {
+
+        @Accessor("customItemModel")
+        ModelResourceLocation getCustomItemModel();
+
+        @Invoker("getOriginalModelLocation")
+        ModelResourceLocation getOriginalModel();
+    }
+
+    // WTF why is Entry class public while Key is private??????
+    // I love you CEu
+    @Mixin(targets = "gregtech.client.model.lamp.LampBakedModel$Key", remap = false)
+    interface KeyAccessor {
+
+        @Accessor("modelType")
+        LampModelType getModelType();
+    }
+}

--- a/src/main/java/supersymmetry/mixins/vintagefix/LampBakedModelMixin.java
+++ b/src/main/java/supersymmetry/mixins/vintagefix/LampBakedModelMixin.java
@@ -1,0 +1,28 @@
+package supersymmetry.mixins.vintagefix;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import gregtech.client.model.lamp.LampBakedModel;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.util.registry.IRegistry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import team.chisel.ctm.client.model.ModelBakedCTM;
+
+@Mixin(value = LampBakedModel.class, remap = false)
+public abstract class LampBakedModelMixin {
+
+    @WrapOperation(method = "onModelBake",
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/util/registry/IRegistry;putObject(Ljava/lang/Object;Ljava/lang/Object;)V",
+                    remap = true))
+    private static void skipIfCTMModel(IRegistry<ModelResourceLocation, IBakedModel> modelRegistry,
+                                       Object key, Object value, Operation<Void> method,
+                                       @Local(name = "model") IBakedModel model) {
+        if (!(model instanceof ModelBakedCTM)) {
+            method.call(modelRegistry, key, value);
+        }
+    }
+}

--- a/src/main/java/supersymmetry/modules/SuSyModules.java
+++ b/src/main/java/supersymmetry/modules/SuSyModules.java
@@ -13,6 +13,7 @@ public class SuSyModules implements IModuleContainer {
     public static final String MODULE_TOP = "susy_top_integration";
     public static final String MODULE_JEI = "susy_jei_integration";
     public static final String MODULE_PYROTECH = "susy_pyrotech_integration";
+    public static final String MODULE_VINTAGEFIX = "susy_vintagefix_integration";
 
     @Override
     public String getID() {

--- a/src/main/resources/mixins.susy.vintagefix.json
+++ b/src/main/resources/mixins.susy.vintagefix.json
@@ -1,0 +1,13 @@
+{
+  "package" : "supersymmetry.mixins.vintagefix",
+  "refmap" : "mixins.susy.refmap.json",
+  "target" : "@env(DEFAULT)",
+  "minVersion" : "0.8",
+  "compatibilityLevel" : "JAVA_8",
+  "client" : [
+    "LampBakedModelMixin",
+    "LampBakedModelAccessor",
+    "LampBakedModelAccessor$EntryAccessor",
+    "LampBakedModelAccessor$KeyAccessor"
+  ]
+}


### PR DESCRIPTION
<img width="2560" height="1494" alt="image" src="https://github.com/user-attachments/assets/4850181e-776d-4ef5-9ada-d8b095f3d648" />

Brute-force approach

might get a better way to fix this from embeddedt in https://github.com/embeddedt/VintageFix/issues/112

so this can wait ig

Tested only in client environment