### PR TITLE
Ol code breacher fix 2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,9 +57,9 @@ dependencies {
     implementation rfg.deobf('curse.maven:immersive-railroading-277736:4970105')
 
     // # Recurrent Complex dependencies
-    compileOnly rfg.deobf('curse.maven:recurrent-complex-223150:5615733')
-    compileOnly rfg.deobf('curse.maven:ivtoolkit-224535:2443253')
-    compileOnly rfg.deobf('curse.maven:fluidlogged-api-485654:4564413')
+    implementation rfg.deobf('curse.maven:recurrent-complex-223150:5615733')
+    implementation rfg.deobf('curse.maven:ivtoolkit-224535:2443253')
+    implementation rfg.deobf('curse.maven:fluidlogged-api-485654:4564413')
 
     // # Pyrotech dependencies
     compileOnly rfg.deobf('curse.maven:pyrotech-306676:5351359')

--- a/src/main/java/supersymmetry/common/metatileentities/storage/MetaTileEntityLockedCrate.java
+++ b/src/main/java/supersymmetry/common/metatileentities/storage/MetaTileEntityLockedCrate.java
@@ -25,6 +25,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
@@ -211,10 +212,14 @@ public class MetaTileEntityLockedCrate extends MetaTileEntity {
     }
 
     @Override
-    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing) {
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             return null;
         }
         return super.getCapability(capability, facing);
+    }
+
+    public ItemStackHandler getInventoryForLootGen() {
+        return inventory;
     }
 }

--- a/src/main/java/supersymmetry/mixins/reccomplex/GenericStructureMixin.java
+++ b/src/main/java/supersymmetry/mixins/reccomplex/GenericStructureMixin.java
@@ -1,0 +1,31 @@
+package supersymmetry.mixins.reccomplex;
+
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import ivorius.reccomplex.world.gen.feature.structure.context.StructureSpawnContext;
+import ivorius.reccomplex.world.storage.loot.LootGenerationHandler;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import supersymmetry.common.metatileentities.storage.MetaTileEntityLockedCrate;
+
+
+
+@Mixin(targets = "ivorius.reccomplex.world.gen.feature.structure.generic.GenericStructure", remap = false)
+public class GenericStructureMixin {
+
+    @Inject(method = "generateTileEntityContents", at = @At("HEAD"), cancellable = true)
+    private static void onGenerateTileEntityContents(StructureSpawnContext context, TileEntity tileEntity, CallbackInfo ci) {
+        if (!context.generateAsSource && tileEntity instanceof IGregTechTileEntity) {
+            MetaTileEntity mte = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
+            if (mte instanceof MetaTileEntityLockedCrate) {
+                IItemHandlerModifiable realInventory = ((MetaTileEntityLockedCrate) mte).getInventoryForLootGen();
+                LootGenerationHandler.generateAllTags(context, realInventory);
+                ci.cancel(); // prevent RecComplex from running its normal (getCapability-based) logic
+            }
+        }
+    }
+}

--- a/src/main/resources/mixins.susy.reccomplex.json
+++ b/src/main/resources/mixins.susy.reccomplex.json
@@ -7,6 +7,7 @@
   "mixins": [
     "StructureSpawnContextMixin",
     "RCPosTransformerMixin",
-    "SpawnCommandLogicMixin"
+    "SpawnCommandLogicMixin",
+    "GenericStructureMixin"
   ]
 }


### PR DESCRIPTION
The Locked Crates are now able to generate RC loot
this was impossible before due to the crates intentionally returning null to getCapability (anti cheese mechanic) but RC also uses that to generate it's loot
Now RC is able to bypass that restriction