### PR TITLE
Ol rc UUID fix

### DIFF
--- a/src/main/java/supersymmetry/mixins/reccomplex/GenericStructureMixin.java
+++ b/src/main/java/supersymmetry/mixins/reccomplex/GenericStructureMixin.java
@@ -1,0 +1,43 @@
+package supersymmetry.mixins.reccomplex;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = ivorius.reccomplex.world.gen.feature.structure.generic.GenericStructure.class, remap = false)
+public class GenericStructureMixin {
+     //Stamp a fresh UUID into the entity NBT before creation
+    @Redirect(
+            method = "generate(Livorius/reccomplex/world/gen/feature/structure/context/StructureSpawnContext;" +
+                    "Livorius/reccomplex/world/gen/feature/structure/generic/GenericStructure$InstanceData;" +
+                    "Livorius/reccomplex/world/gen/feature/structure/generic/TransformerMulti;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/EntityList;createEntityFromNBT(Lnet/minecraft/nbt/NBTTagCompound;Lnet/minecraft/world/World;)Lnet/minecraft/entity/Entity;",
+                    remap = false
+            )
+    )
+    private Entity injectUUIDBeforeCreate(NBTTagCompound entityCompound, World world) {
+        java.util.UUID newUUID = java.util.UUID.randomUUID();
+        entityCompound.setLong("UUIDMost", newUUID.getMostSignificantBits());
+        entityCompound.setLong("UUIDLeast", newUUID.getLeastSignificantBits());
+        return EntityList.createEntityFromNBT(entityCompound, world);
+    }
+
+     //Prevent RC from overriding our baked-in UUID
+    @Redirect(
+            method = "generate(Livorius/reccomplex/world/gen/feature/structure/context/StructureSpawnContext;" +
+                    "Livorius/reccomplex/world/gen/feature/structure/generic/GenericStructure$InstanceData;" +
+                    "Livorius/reccomplex/world/gen/feature/structure/generic/TransformerMulti;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Livorius/reccomplex/utils/accessor/RCAccessorEntity;setEntityUniqueID(Lnet/minecraft/entity/Entity;Ljava/util/UUID;)V",
+                    remap = false
+            )
+    )
+    private static void noopOverrideUUID(Entity entity, java.util.UUID uuid) {}
+}

--- a/src/main/java/supersymmetry/mixins/reccomplex/GenericStructureMixin.java
+++ b/src/main/java/supersymmetry/mixins/reccomplex/GenericStructureMixin.java
@@ -8,36 +8,38 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(value = ivorius.reccomplex.world.gen.feature.structure.generic.GenericStructure.class, remap = false)
+@Mixin(ivorius.reccomplex.world.gen.feature.structure.generic.GenericStructure.class)
 public class GenericStructureMixin {
-     //Stamp a fresh UUID into the entity NBT before creation
+    /**
+     * Stamp a fresh UUID into the NBT just before RC calls EntityList.createEntityFromNBT(...).
+     */
     @Redirect(
-            method = "generate(Livorius/reccomplex/world/gen/feature/structure/context/StructureSpawnContext;" +
-                    "Livorius/reccomplex/world/gen/feature/structure/generic/GenericStructure$InstanceData;" +
-                    "Livorius/reccomplex/world/gen/feature/structure/generic/TransformerMulti;)V",
+            method = "generate",  // literal deobf name
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/entity/EntityList;createEntityFromNBT(Lnet/minecraft/nbt/NBTTagCompound;Lnet/minecraft/world/World;)Lnet/minecraft/entity/Entity;",
-                    remap = false
-            )
+                    target = "Lnet/minecraft/entity/EntityList;createEntityFromNBT(Lnet/minecraft/nbt/NBTTagCompound;Lnet/minecraft/world/World;)Lnet/minecraft/entity/Entity;"
+            ),
+            remap = false
     )
-    private Entity injectUUIDBeforeCreate(NBTTagCompound entityCompound, World world) {
-        java.util.UUID newUUID = java.util.UUID.randomUUID();
-        entityCompound.setLong("UUIDMost", newUUID.getMostSignificantBits());
-        entityCompound.setLong("UUIDLeast", newUUID.getLeastSignificantBits());
-        return EntityList.createEntityFromNBT(entityCompound, world);
+    private Entity injectUUIDBeforeCreate(NBTTagCompound tag, World world) {
+        java.util.UUID id = java.util.UUID.randomUUID();
+        tag.setLong("UUIDMost", id.getMostSignificantBits());
+        tag.setLong("UUIDLeast", id.getLeastSignificantBits());
+        return EntityList.createEntityFromNBT(tag, world);
     }
 
-     //Prevent RC from overriding our baked-in UUID
+    /**
+     * No-op RC’s later call to setEntityUniqueID so we keep our baked-in value.
+     */
     @Redirect(
-            method = "generate(Livorius/reccomplex/world/gen/feature/structure/context/StructureSpawnContext;" +
-                    "Livorius/reccomplex/world/gen/feature/structure/generic/GenericStructure$InstanceData;" +
-                    "Livorius/reccomplex/world/gen/feature/structure/generic/TransformerMulti;)V",
+            method = "generate",  // literal deobf name
             at = @At(
                     value = "INVOKE",
-                    target = "Livorius/reccomplex/utils/accessor/RCAccessorEntity;setEntityUniqueID(Lnet/minecraft/entity/Entity;Ljava/util/UUID;)V",
-                    remap = false
-            )
+                    target = "Livorius/reccomplex/utils/accessor/RCAccessorEntity;setEntityUniqueID(Lnet/minecraft/entity/Entity;Ljava/util/UUID;)V"
+            ),
+            remap = false
     )
-    private static void noopOverrideUUID(Entity entity, java.util.UUID uuid) {}
+    private static void noopOverrideUUID(Entity e, java.util.UUID uuid) {
+        // intentionally empty
+    }
 }

--- a/src/main/resources/mixins.susy.reccomplex.json
+++ b/src/main/resources/mixins.susy.reccomplex.json
@@ -7,6 +7,7 @@
   "mixins": [
     "RCPosTransformerMixin",
     "SpawnCommandLogicMixin",
-    "StructureSpawnContextMixin"
+    "StructureSpawnContextMixin",
+    "GenericStructureMixin"
   ]
 }


### PR DESCRIPTION
Fixes RC assigning broken UUID values to mobs
this caused issues where the mobs were not able to be selected with UUID post-generation, so for example now we can generate structures with script blocks that have a chance to buff certain mobs. For example giving all parasites in a radius the rage effect or federation members regeneration in real time.
Also as a side effect reduces console warn spam from multiple entities with the same UUID being detected