### PR TITLE
Implemented flexible dimensions for the Quarry from 15x15 to 31x31

### DIFF
--- a/src/main/java/supersymmetry/api/util/Grid3D.java
+++ b/src/main/java/supersymmetry/api/util/Grid3D.java
@@ -1,0 +1,238 @@
+package supersymmetry.api.util;
+
+import gregtech.api.pattern.BlockPattern;
+import gregtech.api.pattern.FactoryBlockPattern;
+import gregtech.api.pattern.TraceabilityPredicate;
+import gregtech.api.util.RelativeDirection;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a 3D grid for drawing a multiblock pattern. The origin point (0, 0, 0) is
+ * at the left, bottom, front corner.
+ */
+public class Grid3D
+{
+    private final char[][][] grid;
+    final int width;
+    final int height;
+    final int depth;
+    private final Map<Character, TraceabilityPredicate> symbolMap = new HashMap<>();
+
+    /**
+     * Initializes the grid with the given dimensions and sets all blocks to a space character.
+     *
+     * @param width X dimension, left-right
+     * @param height Y dimension, bottom-top
+     * @param depth Z dimension, front-back
+     */
+    public Grid3D(int width, int height, int depth) {
+        this.width = width;
+        this.height = height;
+        this.depth = depth;
+
+        grid = new char[width][height][depth];
+        for ( int x = 0; x < width; x++ ) {
+            for ( int y = 0; y < height; y++ ) {
+                Arrays.fill(grid[x][y], ' ');
+            }
+        }
+    }
+
+    public Grid3D set(int x, int y, int z, char c) {
+        if ( y < 0 ) {
+            y += height;
+        }
+        if ( x < 0 ) {
+            x += width;
+        }
+        if ( z < 0 ) {
+            z += depth;
+        }
+        grid[x][y][z] = c;
+        return this;
+    }
+
+    public Grid3D where(char symbol, TraceabilityPredicate blockMatcher) {
+        this.symbolMap.put(symbol, new TraceabilityPredicate(blockMatcher).sort());
+        return this;
+    }
+
+    /**
+     * Draws a line on the X axis.
+     *
+     * @param x1
+     * @param y
+     * @param z
+     * @param x2
+     * @param c
+     * @return
+     */
+    public Grid3D lineX(int x1, int y, int z, int x2, char c) {
+        if ( x1 < 0 ) {
+            x1 += width;
+        }
+        if ( x2 < 0 ) {
+            x2 += width;
+        }
+        if ( y < 0 ) {
+            y += height;
+        }
+        if ( z < 0 ) {
+            z += depth;
+        }
+        if ( x1 > x2 ) {
+            int t = x2;
+            x2 = x1;
+            x1 = t;
+        }
+        for ( int x = x1; x <= x2; x++ ) {
+            grid[x][y][z] = c;
+        }
+        return this;
+    }
+
+    /**
+     * Draws a line on the Z axis.
+     *
+     * @param x
+     * @param y
+     * @param z1
+     * @param z2
+     * @param c
+     * @return
+     */
+    public Grid3D lineZ(int x, int y, int z1, int z2, char c) {
+        if ( z1 < 0 ) {
+            z1 += depth;
+        }
+        if ( z2 < 0 ) {
+            z2 += depth;
+        }
+        if ( x < 0 ) {
+            x += width;
+        }
+        if ( y < 0 ) {
+            y += height;
+        }
+        if ( z1 > z2 ) {
+            int t = z2;
+            z2 = z1;
+            z1 = t;
+        }
+        for ( int z = z1; z <= z2; z++ ) {
+            grid[x][y][z] = c;
+        }
+        return this;
+    }
+
+    /**
+     * Draws a line on the Y axis.
+     *
+     * @param x
+     * @param y1
+     * @param z
+     * @param y2
+     * @param c
+     * @return
+     */
+    public Grid3D lineY(int x, int y1, int z, int y2, char c) {
+        if ( y1 < 0 ) {
+            y1 += height;
+        }
+        if ( y2 < 0 ) {
+            y2 += height;
+        }
+        if ( x < 0 ) {
+            x += width;
+        }
+        if ( z < 0 ) {
+            z += depth;
+        }
+        if ( y1 > y2 ) {
+            int t = y2;
+            y2 = y1;
+            y1 = t;
+        }
+        for ( int y = y1; y <= y2; y++ ) {
+            grid[x][y][z] = c;
+        }
+        return this;
+    }
+
+    public Grid3D lineX(int x, int y, int z, String chars) {
+        if ( x < 0 ) {
+            x += width;
+        }
+        if ( y < 0 ) {
+            y += height;
+        }
+        if ( z < 0 ) {
+            z += depth;
+        }
+        for ( int i = x; i < x + chars.length() && i < width; i++ ) {
+            grid[i][y][z] = chars.charAt(i - x);
+        }
+        return this;
+    }
+
+    public Grid3D lineY(int x, int y, int z, String chars) {
+        if ( x < 0 ) {
+            x += width;
+        }
+        if ( y < 0 ) {
+            y += height;
+        }
+        if ( z < 0 ) {
+            z += depth;
+        }
+        for ( int i = y; i < y + chars.length() && i < height; i++ ) {
+            grid[x][i][z] = chars.charAt(i - y);
+        }
+        return this;
+    }
+
+    public Grid3D lineZ(int x, int y, int z, String chars) {
+        if ( x < 0 ) {
+            x += width;
+        }
+        if ( y < 0 ) {
+            y += height;
+        }
+        if ( z < 0 ) {
+            z += depth;
+        }
+        for ( int i = z; i < z + chars.length() && i < depth; i++ ) {
+            grid[x][y][i] = chars.charAt(i - z);
+        }
+        return this;
+    }
+
+    public Grid3D rectXZ(int y, int x1, int z1, int x2, int z2, char c) {
+        lineX(x1, y, z1, x2, c);
+        lineX(x1, y, z2, x2, c);
+        lineZ(x1, y, z1, z2, c);
+        lineZ(x2, y, z1, z2, c);
+        return this;
+    }
+
+    public BlockPattern build() {
+        // characters in string are front-to-back (z direction)
+        // strings in aisle() are bottom-to-top (y direction)
+        // each aisle() call goes from left-to-right (x direction)
+        var pattern = FactoryBlockPattern.start(RelativeDirection.FRONT, RelativeDirection.UP, RelativeDirection.RIGHT);
+        for ( int x = 0; x < grid.length; x++ ) {
+            String[] yzPlane = new String[grid[x].length];
+            for ( int y = 0; y < grid[x].length; y++ ) {
+                yzPlane[y] = String.valueOf(grid[x][y]);
+            }
+
+            pattern.aisle(yzPlane);
+        }
+        this.symbolMap.forEach(pattern::where);
+
+        return pattern.build();
+    }
+}

--- a/src/main/java/supersymmetry/api/util/Grid3D.java
+++ b/src/main/java/supersymmetry/api/util/Grid3D.java
@@ -13,8 +13,7 @@ import java.util.Map;
  * Represents a 3D grid for drawing a multiblock pattern. The origin point (0, 0, 0) is
  * at the left, bottom, front corner.
  */
-public class Grid3D
-{
+public class Grid3D {
     private final char[][][] grid;
     final int width;
     final int height;
@@ -24,9 +23,9 @@ public class Grid3D
     /**
      * Initializes the grid with the given dimensions and sets all blocks to a space character.
      *
-     * @param width X dimension, left-right
+     * @param width  X dimension, left-right
      * @param height Y dimension, bottom-top
-     * @param depth Z dimension, front-back
+     * @param depth  Z dimension, front-back
      */
     public Grid3D(int width, int height, int depth) {
         this.width = width;
@@ -34,21 +33,21 @@ public class Grid3D
         this.depth = depth;
 
         grid = new char[width][height][depth];
-        for ( int x = 0; x < width; x++ ) {
-            for ( int y = 0; y < height; y++ ) {
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
                 Arrays.fill(grid[x][y], ' ');
             }
         }
     }
 
     public Grid3D set(int x, int y, int z, char c) {
-        if ( y < 0 ) {
+        if (y < 0) {
             y += height;
         }
-        if ( x < 0 ) {
+        if (x < 0) {
             x += width;
         }
-        if ( z < 0 ) {
+        if (z < 0) {
             z += depth;
         }
         grid[x][y][z] = c;
@@ -71,24 +70,24 @@ public class Grid3D
      * @return
      */
     public Grid3D lineX(int x1, int y, int z, int x2, char c) {
-        if ( x1 < 0 ) {
+        if (x1 < 0) {
             x1 += width;
         }
-        if ( x2 < 0 ) {
+        if (x2 < 0) {
             x2 += width;
         }
-        if ( y < 0 ) {
+        if (y < 0) {
             y += height;
         }
-        if ( z < 0 ) {
+        if (z < 0) {
             z += depth;
         }
-        if ( x1 > x2 ) {
+        if (x1 > x2) {
             int t = x2;
             x2 = x1;
             x1 = t;
         }
-        for ( int x = x1; x <= x2; x++ ) {
+        for (int x = x1; x <= x2; x++) {
             grid[x][y][z] = c;
         }
         return this;
@@ -105,24 +104,24 @@ public class Grid3D
      * @return
      */
     public Grid3D lineZ(int x, int y, int z1, int z2, char c) {
-        if ( z1 < 0 ) {
+        if (z1 < 0) {
             z1 += depth;
         }
-        if ( z2 < 0 ) {
+        if (z2 < 0) {
             z2 += depth;
         }
-        if ( x < 0 ) {
+        if (x < 0) {
             x += width;
         }
-        if ( y < 0 ) {
+        if (y < 0) {
             y += height;
         }
-        if ( z1 > z2 ) {
+        if (z1 > z2) {
             int t = z2;
             z2 = z1;
             z1 = t;
         }
-        for ( int z = z1; z <= z2; z++ ) {
+        for (int z = z1; z <= z2; z++) {
             grid[x][y][z] = c;
         }
         return this;
@@ -139,72 +138,72 @@ public class Grid3D
      * @return
      */
     public Grid3D lineY(int x, int y1, int z, int y2, char c) {
-        if ( y1 < 0 ) {
+        if (y1 < 0) {
             y1 += height;
         }
-        if ( y2 < 0 ) {
+        if (y2 < 0) {
             y2 += height;
         }
-        if ( x < 0 ) {
+        if (x < 0) {
             x += width;
         }
-        if ( z < 0 ) {
+        if (z < 0) {
             z += depth;
         }
-        if ( y1 > y2 ) {
+        if (y1 > y2) {
             int t = y2;
             y2 = y1;
             y1 = t;
         }
-        for ( int y = y1; y <= y2; y++ ) {
+        for (int y = y1; y <= y2; y++) {
             grid[x][y][z] = c;
         }
         return this;
     }
 
     public Grid3D lineX(int x, int y, int z, String chars) {
-        if ( x < 0 ) {
+        if (x < 0) {
             x += width;
         }
-        if ( y < 0 ) {
+        if (y < 0) {
             y += height;
         }
-        if ( z < 0 ) {
+        if (z < 0) {
             z += depth;
         }
-        for ( int i = x; i < x + chars.length() && i < width; i++ ) {
+        for (int i = x; i < x + chars.length() && i < width; i++) {
             grid[i][y][z] = chars.charAt(i - x);
         }
         return this;
     }
 
     public Grid3D lineY(int x, int y, int z, String chars) {
-        if ( x < 0 ) {
+        if (x < 0) {
             x += width;
         }
-        if ( y < 0 ) {
+        if (y < 0) {
             y += height;
         }
-        if ( z < 0 ) {
+        if (z < 0) {
             z += depth;
         }
-        for ( int i = y; i < y + chars.length() && i < height; i++ ) {
+        for (int i = y; i < y + chars.length() && i < height; i++) {
             grid[x][i][z] = chars.charAt(i - y);
         }
         return this;
     }
 
     public Grid3D lineZ(int x, int y, int z, String chars) {
-        if ( x < 0 ) {
+        if (x < 0) {
             x += width;
         }
-        if ( y < 0 ) {
+        if (y < 0) {
             y += height;
         }
-        if ( z < 0 ) {
+        if (z < 0) {
             z += depth;
         }
-        for ( int i = z; i < z + chars.length() && i < depth; i++ ) {
+        for (int i = z; i < z + chars.length() && i < depth; i++) {
             grid[x][y][i] = chars.charAt(i - z);
         }
         return this;
@@ -223,9 +222,9 @@ public class Grid3D
         // strings in aisle() are bottom-to-top (y direction)
         // each aisle() call goes from left-to-right (x direction)
         var pattern = FactoryBlockPattern.start(RelativeDirection.FRONT, RelativeDirection.UP, RelativeDirection.RIGHT);
-        for ( int x = 0; x < grid.length; x++ ) {
+        for (int x = 0; x < grid.length; x++) {
             String[] yzPlane = new String[grid[x].length];
-            for ( int y = 0; y < grid[x].length; y++ ) {
+            for (int y = 0; y < grid[x].length; y++) {
                 yzPlane[y] = String.valueOf(grid[x][y]);
             }
 

--- a/src/main/java/supersymmetry/api/util/Grid3D.java
+++ b/src/main/java/supersymmetry/api/util/Grid3D.java
@@ -2,12 +2,11 @@ package supersymmetry.api.util;
 
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
+import gregtech.api.pattern.MultiblockShapeInfo;
 import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.util.RelativeDirection;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents a 3D grid for drawing a multiblock pattern. The origin point (0, 0, 0) is
@@ -233,5 +232,34 @@ public class Grid3D {
         this.symbolMap.forEach(pattern::where);
 
         return pattern.build();
+    }
+
+    /**
+     * Makes a shallow copy of the given builder, applies the grid shape to it, and returns the built
+     * shape info. It does not set the keys and block states, those are expected to have been
+     * previously configured.
+     *
+     * @param builder Base builder object with keys configured.
+     * @return The built shape.
+     */
+    public MultiblockShapeInfo buildShape(MultiblockShapeInfo.Builder builder) {
+        // this needs to build as right, up, back.
+        // Each character in a string goes from x=0 to width
+        // Each string in an aisle call goes from y=0 to height
+        // Each aisle call goes from z=depth to 0
+        var copy = builder.shallowCopy();
+        for (int z = depth - 1; z >= 0; z--) {
+            String[] xyPlane = new String[height];
+            for (int y = 0; y < height; y++) {
+                var line = new StringBuilder(width);
+                for (int x = 0; x < width; x++) {
+                    line.append(grid[x][y][z]);
+                }
+                xyPlane[y] = line.toString();
+            }
+
+            copy.aisle(xyPlane);
+        }
+        return copy.build();
     }
 }

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
@@ -10,6 +10,7 @@ import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
+import gregtech.api.pattern.MultiblockShapeInfo;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.unification.material.Materials;
@@ -17,10 +18,12 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.TooltipHelper;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.BlockTurbineCasing;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.blocks.StoneVariantBlock;
+import gregtech.common.metatileentities.MetaTileEntities;
 import it.unimi.dsi.fastutil.ints.IntLists;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
@@ -38,8 +41,10 @@ import supersymmetry.api.gui.SusyGuiTextures;
 import supersymmetry.api.recipes.SuSyRecipeMaps;
 import supersymmetry.api.recipes.properties.DimensionProperty;
 import supersymmetry.api.util.Grid3D;
+import supersymmetry.common.metatileentities.SuSyMetaTileEntities;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.assignId;
@@ -178,88 +183,7 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
             depth = MIN_DIAMETER;
         }
 
-        final var grid = new Grid3D(width, 5, depth)
-                .where('M', selfPredicate())
-                .where('A', states(getCasingState())
-                        .or(autoAbilities(true, true, true, true, false, false, false)))
-                .where('S', states(getCasingState()))
-                .where('C', states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT)))
-                .where('F', frames(Materials.Steel))
-                .where('G', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)));
-
-        // Layer 0
-        // draw a concrete rectangle on the bottom first, we'll overwrite the middle parts after
-        grid.rectXZ(0, 0, 0, width - 1, depth - 1, 'C');
-        // back has frames inset by 5
-        // draw frames for all sides like this, and we'll change mid to AFA (left), AGA (right), AAA (front)
-
-        // This code extends the quarry with concrete by painting over the middle 5 blocks on each side.
-        grid.lineX(width / 2 - 2, 0, -1, "FFFFF"); // back
-        grid.lineX(width / 2 - 2, 0, 0, "FAAAF"); // front
-        grid.lineZ(0, 0, depth / 2 - 2, "FAFAF"); // left
-        grid.lineZ(-1, 0, depth / 2 - 2, "FAGAF"); // right
-
-        // This code extends the quarry with steel frames by painting between 5 and -6 on each side.
-        // I think concrete looks better on the bottom, but if we want frames, we can swap this out.
-//        grid.lineX(5, 0, -1, -6, 'F'); // back
-//        grid.lineX(5, 0, 0, -6, 'F'); // front
-//        grid.lineZ(0, 0, 5, -6, 'F'); // left
-//        grid.lineZ(-1, 0, 5, -6, 'F'); // right
-//
-//        grid.lineX(width / 2 - 1, 0, 0, "AAA"); // front
-//        grid.lineZ(0, 0, depth / 2 - 1, "AFA"); // left
-//        grid.lineZ(-1, 0, depth / 2 - 1, "AGA"); // right
-
-        // inset gearboxes
-        grid.lineZ(1, 0, depth / 2 - 1, "GGG"); // left + 1
-        grid.lineZ(-2, 0, depth / 2 - 1, "GGG"); // right - 1
-
-        // Layer 1
-        // Concrete near corners
-        grid.lineX(0, 1, -1, " CC");
-        grid.lineX(-3, 1, -1, "CC ");
-        grid.lineX(0, 1, 0, " CC");
-        grid.lineX(-3, 1, 0, "CC ");
-        grid.lineZ(0, 1, -3, "CC ");
-        grid.lineZ(-1, 1, -3, "CC ");
-        grid.lineZ(0, 1, 0, " CC");
-        grid.lineZ(-1, 1, 0, " CC");
-
-        // sides and front
-        grid.lineZ(0, 1, depth / 2 - 1, "S S");
-        grid.lineZ(1, 1, depth / 2 - 1, "SGS");
-        grid.lineZ(-2, 1, depth / 2 - 1, "SGS");
-        grid.lineZ(-1, 1, depth / 2 - 1, "S S");
-        grid.lineX(width / 2 - 1, 1, 0, "AMA");
-
-        // Layer 2 and 3 just have a couple side frames. The rest are handled elsewhere.
-        grid.set(1, 2, depth / 2, 'F');
-        grid.set(-2, 2, depth / 2, 'F');
-        grid.set(1, 3, depth / 2, 'F');
-        grid.set(-2, 3, depth / 2, 'F');
-
-        // Layer 4
-        // draw the top as a rect of frames inset by 1, then replace the blocks next to the corners after
-        grid.rectXZ(4, 1, 1, width - 2, depth - 2, 'F');
-
-        // 4 "F" columns inset 1 from the corners that go from y = 0 to 4
-        grid.lineY(1, 0, -2, "FFFFF");
-        grid.lineY(-2, 0, -2, "FFFFF");
-        grid.lineY(1, 0, 1, "FFFFF");
-        grid.lineY(-2, 0, 1, "FFFFF");
-        grid.lineY(width / 2, 0, -1, "FFFFF"); // also one in the back middle
-
-        // 8 "S" columns near the corners that go from y = 0 to 4
-        grid.lineY(2, 0, -2, "SSSSS");
-        grid.lineY(-3, 0, -2, "SSSSS");
-        grid.lineY(1, 0, -3, "SSSSS");
-        grid.lineY(-2, 0, -3, "SSSSS");
-        grid.lineY(1, 0, 2, "SSSSS");
-        grid.lineY(-2, 0, 2, "SSSSS");
-        grid.lineY(2, 0, 1, "SSSSS");
-        grid.lineY(-3, 0, 1, "SSSSS");
-
-        return grid.build();
+        return createGrid(width, depth).build();
 
         // Original pattern below for reference:
         /*return FactoryBlockPattern.start()
@@ -289,9 +213,130 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
                 .build();*/
     }
 
+    private Grid3D createGrid(int quarryWidth, int quarryDepth) {
+        final var grid = new Grid3D(quarryWidth, 5, quarryDepth)
+                .where('M', selfPredicate())
+                .where('A', states(getCasingState())
+                        .or(autoAbilities(true, true, true, true, false, false, false)))
+                .where('S', states(getCasingState()))
+                .where('C', states(getConcreteState()))
+                .where('F', frames(Materials.Steel))
+                .where('G', states(getGearboxState()));
+
+        // Layer 0
+        // draw a concrete rectangle on the bottom first, we'll overwrite the middle parts after
+        grid.rectXZ(0, 0, 0, quarryWidth - 1, quarryDepth - 1, 'C');
+        // back has frames inset by 5
+        // draw frames for all sides like this, and we'll change mid to AFA (left), AGA (right), AAA (front)
+
+        // This code extends the quarry with concrete by painting over the middle 5 blocks on each side.
+        grid.lineX(quarryWidth / 2 - 2, 0, -1, "FFFFF"); // back
+        grid.lineX(quarryWidth / 2 - 2, 0, 0, "FAAAF"); // front
+        grid.lineZ(0, 0, quarryDepth / 2 - 2, "FAFAF"); // left
+        grid.lineZ(-1, 0, quarryDepth / 2 - 2, "FAGAF"); // right
+
+        // This code extends the quarry with steel frames by painting between 5 and -6 on each side.
+        // I think concrete looks better on the bottom, but if we want frames, we can swap this out.
+//        grid.lineX(5, 0, -1, -6, 'F'); // back
+//        grid.lineX(5, 0, 0, -6, 'F'); // front
+//        grid.lineZ(0, 0, 5, -6, 'F'); // left
+//        grid.lineZ(-1, 0, 5, -6, 'F'); // right
+//
+//        grid.lineX(width / 2 - 1, 0, 0, "AAA"); // front
+//        grid.lineZ(0, 0, depth / 2 - 1, "AFA"); // left
+//        grid.lineZ(-1, 0, depth / 2 - 1, "AGA"); // right
+
+        // inset gearboxes
+        grid.lineZ(1, 0, quarryDepth / 2 - 1, "GGG"); // left + 1
+        grid.lineZ(-2, 0, quarryDepth / 2 - 1, "GGG"); // right - 1
+
+        // Layer 1
+        // Concrete near corners
+        grid.lineX(0, 1, -1, " CC");
+        grid.lineX(-3, 1, -1, "CC ");
+        grid.lineX(0, 1, 0, " CC");
+        grid.lineX(-3, 1, 0, "CC ");
+        grid.lineZ(0, 1, -3, "CC ");
+        grid.lineZ(-1, 1, -3, "CC ");
+        grid.lineZ(0, 1, 0, " CC");
+        grid.lineZ(-1, 1, 0, " CC");
+
+        // sides and front
+        grid.lineZ(0, 1, quarryDepth / 2 - 1, "S S");
+        grid.lineZ(1, 1, quarryDepth / 2 - 1, "SGS");
+        grid.lineZ(-2, 1, quarryDepth / 2 - 1, "SGS");
+        grid.lineZ(-1, 1, quarryDepth / 2 - 1, "S S");
+        grid.lineX(quarryWidth / 2 - 1, 1, 0, "AMA");
+
+        // Layer 2 and 3 just have a couple side frames. The rest are handled elsewhere.
+        grid.set(1, 2, quarryDepth / 2, 'F');
+        grid.set(-2, 2, quarryDepth / 2, 'F');
+        grid.set(1, 3, quarryDepth / 2, 'F');
+        grid.set(-2, 3, quarryDepth / 2, 'F');
+
+        // Layer 4
+        // draw the top as a rect of frames inset by 1, then replace the blocks next to the corners after
+        grid.rectXZ(4, 1, 1, quarryWidth - 2, quarryDepth - 2, 'F');
+
+        // 4 "F" columns inset 1 from the corners that go from y = 0 to 4
+        grid.lineY(1, 0, -2, "FFFFF");
+        grid.lineY(-2, 0, -2, "FFFFF");
+        grid.lineY(1, 0, 1, "FFFFF");
+        grid.lineY(-2, 0, 1, "FFFFF");
+        grid.lineY(quarryWidth / 2, 0, -1, "FFFFF"); // also one in the back middle
+
+        // 8 "S" columns near the corners that go from y = 0 to 4
+        grid.lineY(2, 0, -2, "SSSSS");
+        grid.lineY(-3, 0, -2, "SSSSS");
+        grid.lineY(1, 0, -3, "SSSSS");
+        grid.lineY(-2, 0, -3, "SSSSS");
+        grid.lineY(1, 0, 2, "SSSSS");
+        grid.lineY(-2, 0, 2, "SSSSS");
+        grid.lineY(2, 0, 1, "SSSSS");
+        grid.lineY(-3, 0, 1, "SSSSS");
+
+        return grid;
+    }
+
+    private Grid3D createShapeGrid(int quarryWidth, int quarryDepth) {
+        var grid = createGrid(quarryWidth, quarryDepth);
+        // draw over the front to add an input bus, output bus, maint hatch, and energy hatch
+        grid.lineX(quarryWidth / 2 - 1, 1, 0, "IMT");
+        grid.lineX(quarryWidth / 2 - 1, 0, 0, "OAE");
+        return grid;
+    }
+
+    @Override
+    public List<MultiblockShapeInfo> getMatchingShapes() {
+        var builder = new MultiblockShapeInfo.Builder();
+        builder.where('M', SuSyMetaTileEntities.QUARRY, EnumFacing.SOUTH)
+                .where('A', getCasingState())
+                .where('S', getCasingState())
+                .where('C', getConcreteState())
+                .where('F', getSteelFrameState())
+                .where('G', getGearboxState())
+                .where('I', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.LV], EnumFacing.SOUTH)
+                .where('O', MetaTileEntities.ITEM_EXPORT_BUS[GTValues.LV], EnumFacing.SOUTH)
+                .where('E', MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.LV], EnumFacing.SOUTH)
+                .where('T',
+                        () -> ConfigHolder.machines.enableMaintenance ? MetaTileEntities.MAINTENANCE_HATCH :
+                                getCasingState(), EnumFacing.SOUTH);
+
+        ArrayList<MultiblockShapeInfo> shapeInfo = new ArrayList<>();
+        // add min, rectangular, max size
+        shapeInfo.add(createShapeGrid(15, 15).buildShape(builder));
+        shapeInfo.add(createShapeGrid(23, 15).buildShape(builder));
+        shapeInfo.add(createShapeGrid(31, 31).buildShape(builder));
+        return shapeInfo;
+    }
 
     protected static IBlockState getCasingState() {
         return MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.STEEL_SOLID);
+    }
+
+    private static IBlockState getConcreteState() {
+        return MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH)
+                .getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT);
     }
 
     @Override

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
@@ -412,18 +412,27 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
     @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
-        this.quarryLogic.readFromNBT(data.getCompoundTag("quarryLogic"));
         this.excavationMode = data.getBoolean("excavationMode");
         this.excavationProgress = data.getInteger("excavationProgress");
         this.excavationActive = data.getBoolean("excavationActive");
         this.width = data.hasKey("width") ? data.getInteger("width") : this.width;
         this.depth = data.hasKey("depth") ? data.getInteger("depth") : this.depth;
-        this.isInitialized = true;
+
+        // If we didn't write the logic, then it wasn't initialized yet.
+        if (data.hasKey("quarryLogic")) {
+            this.quarryLogic.readFromNBT(data.getCompoundTag("quarryLogic"));
+            this.isInitialized = true;
+        } else {
+            this.isInitialized = false;
+        }
     }
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
-        data.setTag("quarryLogic", this.quarryLogic.writeToNBT());
+        // don't write logic before it's initialized since it will NPE
+        if (isInitialized) {
+            data.setTag("quarryLogic", this.quarryLogic.writeToNBT());
+        }
         data.setBoolean("excavationMode", this.excavationMode);
         data.setInteger("excavationProgress", this.excavationProgress);
         data.setBoolean("excavationActive", this.excavationActive);

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
@@ -49,6 +49,7 @@ import static gregtech.api.capability.GregtechDataCodes.assignId;
  * similar to {@link gregtech.common.metatileentities.multi.electric.MetaTileEntityLargeMiner} that allows
  * from breaking block in game.
  * For this it uses {@link QuarryLogic}
+ *
  * @author h3tR / RMI / Crindigo
  */
 
@@ -111,14 +112,14 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
         // Go behind the controller until it sees a frame to find the depth. Only support odd dimensions.
         int depth = 0;
         for (int i = MIN_DIAMETER; i <= MAX_DIAMETER; i += 2) {
-            if ( world.getBlockState(pos) == getSteelFrameState() ) {
+            if (world.getBlockState(pos) == getSteelFrameState()) {
                 depth = i;
                 break;
             }
             pos.move(back, 2);
         }
 
-        if ( depth < MIN_DIAMETER ) {
+        if (depth < MIN_DIAMETER) {
             invalidateStructure();
             return false;
         }
@@ -132,14 +133,14 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
         pos.move(left, minRadius - 1); // earliest possible position
 
         int width = 0;
-        for (int i = minRadius - 1; i <= maxRadius - 1; i++ ) {
-            if ( world.getBlockState(pos) == getGearboxState() ) {
+        for (int i = minRadius - 1; i <= maxRadius - 1; i++) {
+            if (world.getBlockState(pos) == getGearboxState()) {
                 width = 3 + (i * 2);
             }
             pos.move(left);
         }
 
-        if ( width < MIN_DIAMETER ) {
+        if (width < MIN_DIAMETER) {
             invalidateStructure();
             return false;
         }
@@ -312,7 +313,7 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
     @Override
     protected void formStructure(PatternMatchContext context) {
         super.formStructure(context);
-        if(!this.isInitialized)
+        if (!this.isInitialized)
             quarryLogic.init();
         this.isInitialized = true;
     }
@@ -335,52 +336,52 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
 
     private void setExcavationMode(int mode) {
         this.excavationMode = mode == 1;
-        if(this.excavationMode)
+        if (this.excavationMode)
             this.quarryLogic.init(); //reset quarrylogic
     }
 
     @Override
     protected void updateFormedValid() {
-        if(getWorld().isRemote || !this.recipeMapWorkable.isWorkingEnabled()) return;
+        if (getWorld().isRemote || !this.recipeMapWorkable.isWorkingEnabled()) return;
 
-        if (this.excavationMode && !this.quarryLogic.finished && this.drainEnergy(true) && this.getNumMaintenanceProblems() <= 5){
+        if (this.excavationMode && !this.quarryLogic.finished && this.drainEnergy(true) && this.getNumMaintenanceProblems() <= 5) {
             this.drainEnergy(false);
             excavationProgress++;
-            if(!excavationActive) toggleExcavationActive();
+            if (!excavationActive) toggleExcavationActive();
 
             if (excavationProgress % getTicksPerExcavation() == 0)
                 this.quarryLogic.doQuarryOperation();
-        } else{
-            if(excavationActive) toggleExcavationActive();
+        } else {
+            if (excavationActive) toggleExcavationActive();
 
             this.recipeMapWorkable.updateWorkable();
         }
     }
 
-    private void toggleExcavationActive(){
+    private void toggleExcavationActive() {
         excavationActive = !excavationActive;
         writeCustomData(QUARRY_EXCAVATION_ACTIVE, buf -> buf.writeBoolean(excavationActive));
     }
 
     @Override
     protected void addDisplayText(List<ITextComponent> textList) {
-        if(excavationMode)
+        if (excavationMode)
             MultiblockDisplayText.builder(textList, isStructureFormed())
                     .setWorkingStatus(recipeMapWorkable.isWorkingEnabled(), excavationActive)
                     .addEnergyUsageLine(recipeMapWorkable.getEnergyContainer())
                     .addWorkingStatusLine();
         else
             MultiblockDisplayText.builder(textList, isStructureFormed())
-                .setWorkingStatus(recipeMapWorkable.isWorkingEnabled(), recipeMapWorkable.isActive())
-                .addEnergyUsageLine(recipeMapWorkable.getEnergyContainer())
-                .addEnergyTierLine(GTUtility.getTierByVoltage(recipeMapWorkable.getMaxVoltage()))
-                .addParallelsLine(recipeMapWorkable.getParallelLimit())
-                .addWorkingStatusLine()
-                .addProgressLine(recipeMapWorkable.getProgressPercent());
+                    .setWorkingStatus(recipeMapWorkable.isWorkingEnabled(), recipeMapWorkable.isActive())
+                    .addEnergyUsageLine(recipeMapWorkable.getEnergyContainer())
+                    .addEnergyTierLine(GTUtility.getTierByVoltage(recipeMapWorkable.getMaxVoltage()))
+                    .addParallelsLine(recipeMapWorkable.getParallelLimit())
+                    .addWorkingStatusLine()
+                    .addProgressLine(recipeMapWorkable.getProgressPercent());
     }
 
-    public int getTicksPerExcavation(){
-        return (int) (BASE_TICKS_PER_EXCAVATION / Math.pow(2,getEnergyTier() - 1));
+    public int getTicksPerExcavation() {
+        return (int) (BASE_TICKS_PER_EXCAVATION / Math.pow(2, getEnergyTier() - 1));
     }
 
     //cap to EV tier

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
@@ -1,6 +1,7 @@
 package supersymmetry.common.metatileentities.multi.electric;
 
 import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.ImageCycleButtonWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -9,40 +10,52 @@ import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
-import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.client.utils.TooltipHelper;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.BlockTurbineCasing;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.blocks.StoneVariantBlock;
 import it.unimi.dsi.fastutil.ints.IntLists;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 import supersymmetry.api.capability.impl.QuarryLogic;
 import supersymmetry.api.gui.SusyGuiTextures;
 import supersymmetry.api.recipes.SuSyRecipeMaps;
 import supersymmetry.api.recipes.properties.DimensionProperty;
+import supersymmetry.api.util.Grid3D;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.assignId;
 
-/** The quarry multiblock is a regular {@link RecipeMapMultiblockController}, with an additional mode similar to {@link gregtech.common.metatileentities.multi.electric.MetaTileEntityLargeMiner} that allows from breaking block in game.
+/**
+ * The quarry multiblock is a regular {@link RecipeMapMultiblockController}, with an additional mode
+ * similar to {@link gregtech.common.metatileentities.multi.electric.MetaTileEntityLargeMiner} that allows
+ * from breaking block in game.
  * For this it uses {@link QuarryLogic}
- * @author h3tR / RMI
+ * @author h3tR / RMI / Crindigo
  */
 
 public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
+
+    private static final int MAX_DIAMETER = 31;
+    private static final int MIN_DIAMETER = 15;
 
     private static final int BASE_TICKS_PER_EXCAVATION = 10;
 
@@ -54,21 +67,201 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
     private boolean excavationActive = false;
     private int excavationProgress = 0;
     private final QuarryLogic quarryLogic;
+    private int width;
+    private int depth;
 
     public MetaTileEntityQuarry(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, SuSyRecipeMaps.QUARRY_RECIPES);
         this.quarryLogic = new QuarryLogic(this);
     }
-    @Override
 
+    @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity iGregTechTileEntity) {
         return new MetaTileEntityQuarry(this.metaTileEntityId);
     }
 
     @Override
-    protected @NotNull BlockPattern createStructurePattern() {
+    public void checkStructurePattern() {
+        if (!this.isStructureFormed()) {
+            reinitializeStructurePattern();
+        }
+        super.checkStructurePattern();
+    }
 
-        return FactoryBlockPattern.start()
+    public int getWidth() {
+        return width;
+    }
+
+    public int getDepth() {
+        return depth;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean updateStructureDimensions() {
+
+        World world = getWorld();
+        EnumFacing front = getFrontFacing();
+        EnumFacing back = front.getOpposite();
+        EnumFacing right = front.rotateYCCW(); /// right as if you were looking at it, not controller's left
+        EnumFacing left = right.getOpposite();
+
+        // Start looking at the min diameter
+        BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(getPos().offset(back, MIN_DIAMETER - 1));
+
+        // Go behind the controller until it sees a frame to find the depth. Only support odd dimensions.
+        int depth = 0;
+        for (int i = MIN_DIAMETER; i <= MAX_DIAMETER; i += 2) {
+            if ( world.getBlockState(pos) == getSteelFrameState() ) {
+                depth = i;
+                break;
+            }
+            pos.move(back, 2);
+        }
+
+        if ( depth < MIN_DIAMETER ) {
+            invalidateStructure();
+            return false;
+        }
+
+        // Then take the depth divided by 2 and look to the left to find a gearbox. It is inset
+        // by one block, so the radius is that plus 1.
+        final int minRadius = MIN_DIAMETER / 2;
+        final int maxRadius = MAX_DIAMETER / 2;
+
+        pos.move(front, depth / 2); // midpoint of the quarry
+        pos.move(left, minRadius - 1); // earliest possible position
+
+        int width = 0;
+        for (int i = minRadius - 1; i <= maxRadius - 1; i++ ) {
+            if ( world.getBlockState(pos) == getGearboxState() ) {
+                width = 3 + (i * 2);
+            }
+            pos.move(left);
+        }
+
+        if ( width < MIN_DIAMETER ) {
+            invalidateStructure();
+            return false;
+        }
+
+        this.width = width;
+        this.depth = depth;
+
+        writeCustomData(GregtechDataCodes.UPDATE_STRUCTURE_SIZE, buf -> {
+            buf.writeInt(this.width);
+            buf.writeInt(this.depth);
+        });
+
+        return true;
+    }
+
+    protected static IBlockState getSteelFrameState() {
+        // Technically won't work with embedded pipes, but there's no huge reason to have them
+        // on that part of the quarry.
+        return MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel);
+    }
+
+    protected static IBlockState getGearboxState() {
+        return MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX);
+    }
+
+    @Override
+    protected @NotNull BlockPattern createStructurePattern() {
+        if (getWorld() != null) updateStructureDimensions();
+
+        // for auto build
+        if (width < MIN_DIAMETER) {
+            width = MIN_DIAMETER;
+        }
+        if (depth < MIN_DIAMETER) {
+            depth = MIN_DIAMETER;
+        }
+
+        final var grid = new Grid3D(width, 5, depth)
+                .where('M', selfPredicate())
+                .where('A', states(getCasingState())
+                        .or(autoAbilities(true, true, true, true, false, false, false)))
+                .where('S', states(getCasingState()))
+                .where('C', states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT)))
+                .where('F', frames(Materials.Steel))
+                .where('G', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)));
+
+        // Layer 0
+        // draw a concrete rectangle on the bottom first, we'll overwrite the middle parts after
+        grid.rectXZ(0, 0, 0, width - 1, depth - 1, 'C');
+        // back has frames inset by 5
+        // draw frames for all sides like this, and we'll change mid to AFA (left), AGA (right), AAA (front)
+
+        // This code extends the quarry with concrete by painting over the middle 5 blocks on each side.
+        grid.lineX(width / 2 - 2, 0, -1, "FFFFF"); // back
+        grid.lineX(width / 2 - 2, 0, 0, "FAAAF"); // front
+        grid.lineZ(0, 0, depth / 2 - 2, "FAFAF"); // left
+        grid.lineZ(-1, 0, depth / 2 - 2, "FAGAF"); // right
+
+        // This code extends the quarry with steel frames by painting between 5 and -6 on each side.
+        // I think concrete looks better on the bottom, but if we want frames, we can swap this out.
+//        grid.lineX(5, 0, -1, -6, 'F'); // back
+//        grid.lineX(5, 0, 0, -6, 'F'); // front
+//        grid.lineZ(0, 0, 5, -6, 'F'); // left
+//        grid.lineZ(-1, 0, 5, -6, 'F'); // right
+//
+//        grid.lineX(width / 2 - 1, 0, 0, "AAA"); // front
+//        grid.lineZ(0, 0, depth / 2 - 1, "AFA"); // left
+//        grid.lineZ(-1, 0, depth / 2 - 1, "AGA"); // right
+
+        // inset gearboxes
+        grid.lineZ(1, 0, depth / 2 - 1, "GGG"); // left + 1
+        grid.lineZ(-2, 0, depth / 2 - 1, "GGG"); // right - 1
+
+        // Layer 1
+        // Concrete near corners
+        grid.lineX(0, 1, -1, " CC");
+        grid.lineX(-3, 1, -1, "CC ");
+        grid.lineX(0, 1, 0, " CC");
+        grid.lineX(-3, 1, 0, "CC ");
+        grid.lineZ(0, 1, -3, "CC ");
+        grid.lineZ(-1, 1, -3, "CC ");
+        grid.lineZ(0, 1, 0, " CC");
+        grid.lineZ(-1, 1, 0, " CC");
+
+        // sides and front
+        grid.lineZ(0, 1, depth / 2 - 1, "S S");
+        grid.lineZ(1, 1, depth / 2 - 1, "SGS");
+        grid.lineZ(-2, 1, depth / 2 - 1, "SGS");
+        grid.lineZ(-1, 1, depth / 2 - 1, "S S");
+        grid.lineX(width / 2 - 1, 1, 0, "AMA");
+
+        // Layer 2 and 3 just have a couple side frames. The rest are handled elsewhere.
+        grid.set(1, 2, depth / 2, 'F');
+        grid.set(-2, 2, depth / 2, 'F');
+        grid.set(1, 3, depth / 2, 'F');
+        grid.set(-2, 3, depth / 2, 'F');
+
+        // Layer 4
+        // draw the top as a rect of frames inset by 1, then replace the blocks next to the corners after
+        grid.rectXZ(4, 1, 1, width - 2, depth - 2, 'F');
+
+        // 4 "F" columns inset 1 from the corners that go from y = 0 to 4
+        grid.lineY(1, 0, -2, "FFFFF");
+        grid.lineY(-2, 0, -2, "FFFFF");
+        grid.lineY(1, 0, 1, "FFFFF");
+        grid.lineY(-2, 0, 1, "FFFFF");
+        grid.lineY(width / 2, 0, -1, "FFFFF"); // also one in the back middle
+
+        // 8 "S" columns near the corners that go from y = 0 to 4
+        grid.lineY(2, 0, -2, "SSSSS");
+        grid.lineY(-3, 0, -2, "SSSSS");
+        grid.lineY(1, 0, -3, "SSSSS");
+        grid.lineY(-2, 0, -3, "SSSSS");
+        grid.lineY(1, 0, 2, "SSSSS");
+        grid.lineY(-2, 0, 2, "SSSSS");
+        grid.lineY(2, 0, 1, "SSSSS");
+        grid.lineY(-3, 0, 1, "SSSSS");
+
+        return grid.build();
+
+        // Original pattern below for reference:
+        /*return FactoryBlockPattern.start()
                 .aisle("CCCCCFFFFFCCCCC", " CC    F    CC ", "       F       ", "       F       ", "       F       ")
                 .aisle("CFS         SFC", "CFS         SFC", " FS         SF ", " FS         SF ", " FSFFFFFFFFFSF ")
                 .aisle("CS           SC", "CS           SC", " S           S ", " S           S ", " S           S ")
@@ -92,7 +285,7 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
                 .where('C', states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH).getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT)))
                 .where('F', frames(Materials.Steel))
                 .where('G', states(MetaBlocks.TURBINE_CASING.getState(BlockTurbineCasing.TurbineCasingType.STEEL_GEARBOX)))
-                .build();
+                .build();*/
     }
 
 
@@ -206,6 +399,14 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
         return false;
     }
 
+    @Override
+    public void addInformation(ItemStack stack, World player, @NotNull List<String> tooltip, boolean advanced) {
+        super.addInformation(stack, player, tooltip, advanced);
+        tooltip.add(I18n.format("susy.machine.quarry.tooltip.info", MAX_DIAMETER, MIN_DIAMETER));
+        if (TooltipHelper.isShiftDown()) {
+            tooltip.add(I18n.format("susy.machine.quarry.tooltip.structure_info", MAX_DIAMETER, MIN_DIAMETER));
+        }
+    }
 
     @Override
     public void readFromNBT(NBTTagCompound data) {
@@ -214,6 +415,8 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
         this.excavationMode = data.getBoolean("excavationMode");
         this.excavationProgress = data.getInteger("excavationProgress");
         this.excavationActive = data.getBoolean("excavationActive");
+        this.width = data.hasKey("width") ? data.getInteger("width") : this.width;
+        this.depth = data.hasKey("depth") ? data.getInteger("depth") : this.depth;
         this.isInitialized = true;
     }
 
@@ -223,13 +426,20 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
         data.setBoolean("excavationMode", this.excavationMode);
         data.setInteger("excavationProgress", this.excavationProgress);
         data.setBoolean("excavationActive", this.excavationActive);
+        data.setInteger("width", this.width);
+        data.setInteger("depth", this.depth);
         return super.writeToNBT(data);
     }
 
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
-        if (dataId == QUARRY_EXCAVATION_ACTIVE)
+        if (dataId == QUARRY_EXCAVATION_ACTIVE) {
             excavationActive = buf.readBoolean();
+        }
+        if (dataId == GregtechDataCodes.UPDATE_STRUCTURE_SIZE) {
+            this.width = buf.readInt();
+            this.depth = buf.readInt();
+        }
         super.receiveCustomData(dataId, buf);
     }
 
@@ -237,6 +447,8 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
     public void writeInitialSyncData(PacketBuffer buf) {
         buf.writeBoolean(excavationActive);
         buf.writeBoolean(excavationMode);
+        buf.writeInt(width);
+        buf.writeInt(depth);
         super.writeInitialSyncData(buf);
     }
 
@@ -244,6 +456,8 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
     public void receiveInitialSyncData(PacketBuffer buf) {
         excavationActive = buf.readBoolean();
         excavationMode = buf.readBoolean();
+        width = buf.readInt();
+        depth = buf.readInt();
         super.receiveInitialSyncData(buf);
     }
 

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -1070,6 +1070,8 @@ susy.fluid.voiding.flammable=Voidable with Flare Stack
 # Quarry Modes
 susy.multiblock.quarry.excavation_mode=Excavation Mode
 susy.multiblock.quarry.recipe_mode=Recipe Mode
+susy.machine.quarry.tooltip.info=Max square of %1$sx%1$s, minimum %2$sx%2$s. Hold shift for more details.
+susy.machine.quarry.tooltip.structure_info=Quarries can be formed with any odd dimensions ranging from %2$sx%2$s to %1$sx%1$s, even if it is non-square. Extend the bottom layer of concrete blocks on the corners, so a 23-wide quarry will have 9 concrete per side, and 5 inside blocks.
 
 death.attack.toxic_atmo=%s's lungs were shredded
 death.attack.suffocation=%s couldn't breathe


### PR DESCRIPTION
Allows the quarry to be resizable up to 31x31 and permits non-square sizes. Also adds a Grid3D utility for easier (IMO) construction of dynamically-sized multiblocks. Tested this out using both Client and Server+Client, only issue was a non-crashing NPE that would have existed previously, where QuarryLogic was trying to write layerProgression to NBT before the value was initialized.