### PR TITLE
Set the minimum duration of 40s to only be for drone pad recipes

### DIFF
--- a/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
+++ b/src/main/java/supersymmetry/api/recipes/SuSyRecipeMaps.java
@@ -308,7 +308,7 @@ public class SuSyRecipeMaps {
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, ProgressWidget.MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.MINER);
 
-    public static final RecipeMap<DimensionRecipeBuilder> DRONE_PAD = new RecipeMap<>("drone_pad", 4, 9, 0, 0, new DimensionRecipeBuilder(), false);
+    public static final RecipeMap<DimensionRecipeBuilder> DRONE_PAD = new RecipeMap<>("drone_pad", 4, 9, 0, 0, new DimensionRecipeBuilder().minimumDuration(800), false);
 
     public static final RecipeMap<SimpleRecipeBuilder> BLENDER_RECIPES = new RecipeMap<>("blender", 9, 1, 6, 2, new SimpleRecipeBuilder().EUt(VA[LV]), false)
             .setSlotOverlay(false, false, false, GuiTextures.MOLECULAR_OVERLAY_1)

--- a/src/main/java/supersymmetry/api/recipes/builders/DimensionRecipeBuilder.java
+++ b/src/main/java/supersymmetry/api/recipes/builders/DimensionRecipeBuilder.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 public class DimensionRecipeBuilder extends RecipeBuilder<DimensionRecipeBuilder> {
 
+    private int minimumDuration = 0;
 
     public DimensionRecipeBuilder() {
     }
@@ -63,7 +64,12 @@ public class DimensionRecipeBuilder extends RecipeBuilder<DimensionRecipeBuilder
 
     @Override
     public DimensionRecipeBuilder duration(int duration) {
-        return super.duration(Math.max(duration, 800));
+        return super.duration(Math.max(duration, this.minimumDuration));
+    }
+
+    public DimensionRecipeBuilder minimumDuration(int minimumDuration) {
+        this.minimumDuration = minimumDuration;
+        return this;
     }
 
     public IntList getDimensionIDs() {


### PR DESCRIPTION
Quarry recipes in-game were always 40 seconds because they used the DimensionRecipeBuilder which had a hard-coded 40s min duration (for drone recipes). This makes it so the minimum duration only applies to drone pad recipes.