### PR TITLE
fix polymerization tank hatch restriction

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPolymerizationTank.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPolymerizationTank.java
@@ -46,9 +46,11 @@ public class MetaTileEntityPolymerizationTank extends RecipeMapMultiblockControl
                 .where('S', this.selfPredicate())
                 .where('F', frames(Materials.Steel))
                 .where('P', states(getPipeCasingState()))
-                .where('X', states(getCasingState()).setMinGlobalLimited(21)
-                        .or(this.autoAbilities(true, true, true, true, false, false, false)))
-                        .or(this.autoAbilities(false, false, false, false, true, true, false).setMaxGlobalLimited(3))) /* limits fluid hatch to 3 */
+                .where('X', states(getCasingState()).setMinGlobalLimited(20)
+                        .or(this.autoAbilities(true, true, false, false, false, false, false))
+                        .or(this.autoAbilities(false, false, false, false, true, false, false).setMaxGlobalLimited(3))
+                        .or(this.autoAbilities(false, false, false, false, false, true, false).setMaxGlobalLimited(2))
+                        .or(this.autoAbilities(false, false, true, true, false, false, false).setMaxGlobalLimited(1)))
                 .build();
     }
     public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {


### PR DESCRIPTION
# what it does
makes limit on fluid based on how much slots it has in recipes, increased casing limit just to make sure so people don't frugal out