### PR TITLE
Fixes LT crash when a model is exploded

### DIFF
--- a/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
+++ b/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
@@ -16,7 +16,8 @@ public class SuSyLateMixinLoader implements ILateMixinLoader {
             "xnet",
             "travelersbackpack",
             "reccomplex",
-            "fluidlogged_api"
+            "fluidlogged_api",
+            "littletiles"
     );
 
     @Override

--- a/src/main/java/supersymmetry/mixins/littletiles/StructureTileList_GetTileEntity_GuardMixin.java
+++ b/src/main/java/supersymmetry/mixins/littletiles/StructureTileList_GetTileEntity_GuardMixin.java
@@ -1,0 +1,48 @@
+package supersymmetry.mixins.littletiles;
+
+import com.creativemd.littletiles.common.tile.parent.StructureTileList;
+import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
+import com.creativemd.littletiles.common.structure.exception.NotYetConnectedException;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Prevent NPEs during explosions by guarding the call to getTe() inside getTileEntity().
+ *
+ * Original code in StructureTileList#getTileEntity() does: World world = this.getTe().getWorld();
+ *  If the parent was nulled by removal (explosion), getTe() NPEs.
+ *  We redirect that invocation and:
+ *  if this list is detached (isRemoved()), throw NotYetConnectedException (the method already declares this),
+ *  otherwise, call the original getTe() via an @Invoker and validate it isn't null/invalid.
+ *  Hopefully this doesn't cause problems :troll:
+ */
+@Mixin(value = StructureTileList.class, remap = false)
+public abstract class StructureTileList_GetTileEntity_GuardMixin {
+
+    @Invoker("getTe")
+    protected abstract TileEntityLittleTiles susy$invokeGetTe();
+
+    @Redirect( //probably not the best injector, counter argument: its past midnight
+            method = "getTileEntity",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/creativemd/littletiles/common/tile/parent/StructureTileList;getTe()Lcom/creativemd/littletiles/common/tileentity/TileEntityLittleTiles;"
+            ),
+            remap = false
+    )
+    private TileEntityLittleTiles susy$guardGetTeForGetTileEntity(StructureTileList self) throws NotYetConnectedException {
+        if (((StructureTileList) (Object) this).isRemoved()) {
+            // Parent was nulled (e.g., exploded out). Signal "not yet connected" instead of NPE.
+            throw new NotYetConnectedException(); //this spams console with errors when a LT is exploded but it won't crash anymore.
+        }
+
+        TileEntityLittleTiles te = this.susy$invokeGetTe();
+        if (te == null || te.isInvalid()) {
+            throw new NotYetConnectedException();
+        }
+
+        return te;
+    }
+}

--- a/src/main/resources/mixins.susy.littletiles.json
+++ b/src/main/resources/mixins.susy.littletiles.json
@@ -1,0 +1,10 @@
+{
+  "package": "supersymmetry.mixins.littletiles",
+  "refmap": "mixins.susy.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "StructureTileList_GetTileEntity_GuardMixin"
+  ]
+}


### PR DESCRIPTION
see for more details: https://discord.com/channels/881234100504109166/1336000528106389564

TLDR for testing:
exploding a littletile before caused the game to crash, this happen because a "child" of the model (like the moving doors or smth like that) checked for a parent that was already removed, which caused a npe.

To test whether this works or not, just get a techguns rocket launcher, generate yourself a nether lab with `/#gen LabEntrance` and go ham on it! Make sure you disable safe mode otherwise the gun won't break blocks.
If you don't crash then it means that the mixin works, granted it will scream in the console but at least we aren't risking crashing multiplayer servers anymore because someone explodes a lt somewhere

If someone wants to convert this from a mixin to a proper LT fix and make a PR to the original mod you are welcome to.