### PR TITLE
Shows the proper size in right-click preview for some multis

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityEvaporationPool.java
@@ -252,15 +252,27 @@ public class MetaTileEntityEvaporationPool extends RecipeMapMultiblockController
     @Override
     public List<MultiblockShapeInfo> getMatchingShapes() {
         ArrayList<MultiblockShapeInfo> shapeInfo = new ArrayList<>();
-        int l = 3, r =3;
+        // set the default to 5x5 if the shape is not valid
+        int l = 3, r = 3, depth = 5;
+        if (lDist + rDist + 3 >= MIN_DIAMETER) {
+            l = Math.max(lDist, 1);
+            r = Math.max(rDist, 1);
+        }
+
+        if (bDist + 4 >= MIN_DIAMETER) {
+            depth = bDist;
+        }
+
         MultiblockShapeInfo.Builder builder = MultiblockShapeInfo.builder()
                 .aisle(Slice.B_P_HATCHES.gen(l, r), Slice.T_NONE.gen(l, r))
                 .aisle(Slice.B_ALL.gen(l, r), Slice.T_SIDES.gen(l, r))
-                .aisle(Slice.B_END.gen(l, r), Slice.T_MIDDLE.gen(l, r))
-                .aisle(Slice.B_MIDDLE.gen(l, r), Slice.T_MIDDLE.gen(l, r))
-                .aisle(Slice.B_MIDDLE.gen(l, r), Slice.T_MIDDLE.gen(l, r))
-                .aisle(Slice.B_MIDDLE.gen(l, r), Slice.T_MIDDLE.gen(l, r))
-                .aisle(Slice.B_START.gen(l, r), Slice.T_MIDDLE.gen(l, r))
+                .aisle(Slice.B_END.gen(l, r), Slice.T_MIDDLE.gen(l, r));
+
+        for (int i = 0; i < depth - 2; i++) {
+            builder.aisle(Slice.B_MIDDLE.gen(l, r), Slice.T_MIDDLE.gen(l, r));
+        }
+
+        builder.aisle(Slice.B_START.gen(l, r), Slice.T_MIDDLE.gen(l, r))
                 .aisle(Slice.B_ALL.gen(l, r), Slice.T_SIDES.gen(l, r))
                 .aisle(Slice.B_SELF.gen(l, r), Slice.T_NONE.gen(l, r))
                 .where('S', SuSyMetaTileEntities.EVAPORATION_POOL, EnumFacing.SOUTH)

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMixerSettler.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityMixerSettler.java
@@ -343,7 +343,7 @@ public class MetaTileEntityMixerSettler extends RecipeMapMultiblockController {
         }
 
         List<MultiblockShapeInfo> shapeInfo = new ArrayList<>();
-        int radius = MIN_RADIUS;
+        int radius = Math.max(sDist, MIN_RADIUS);
         while (radius <= MAX_RADIUS) {
             shapeInfo.add(new MultiblockShapeInfo(createStructurePattern(radius).getPreview(new int[]{1, 1, 1, 1, 1})));
             radius += 2;

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityQuarry.java
@@ -324,7 +324,8 @@ public class MetaTileEntityQuarry extends RecipeMapMultiblockController {
 
         ArrayList<MultiblockShapeInfo> shapeInfo = new ArrayList<>();
         // add min, rectangular, max size
-        shapeInfo.add(createShapeGrid(15, 15).buildShape(builder));
+        // add current size first for multiblock preview
+        shapeInfo.add(createShapeGrid(Math.max(width, MIN_DIAMETER), Math.max(depth, MIN_DIAMETER)).buildShape(builder));
         shapeInfo.add(createShapeGrid(23, 15).buildShape(builder));
         shapeInfo.add(createShapeGrid(31, 31).buildShape(builder));
         return shapeInfo;


### PR DESCRIPTION
Certain bounding blocks are required:
- Quarries need the left side gearboxes and rear frames
- Mixer-Settlers need the solid steel casings to the left and right of the controller
- Evaporation Pools need three concrete blocks that touch the evaporation bed: one on the opposite side, and one to the left and right of the bed, 2 blocks behind the controller

Another note is that the auto build *already works* if the bounding blocks are correctly placed, since that uses createStructurePattern.