### PR TITLE
Allow buses for Sieve Distillation Towers

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySieveDistillationTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntitySieveDistillationTower.java
@@ -70,6 +70,7 @@ public class MetaTileEntitySieveDistillationTower extends MetaTileEntityOrderedD
                 .where('S', selfPredicate())
                 .where('Y', states(getCasingState())
                         .or(abilities(MultiblockAbility.EXPORT_ITEMS).setMaxGlobalLimited(1))
+                        .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1))
                         .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2))
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1).setMaxGlobalLimited(2)))
                 .where('X', states(getCasingState())


### PR DESCRIPTION
Some sieve DT recipes require a catalyst or a circuit number, but the structure doesn't allow input buses. 
This PR allows sieve DTs to have 1 input bus on the controller layer.