### PR TITLE
Fancy explosions

### DIFF
--- a/src/main/java/supersymmetry/api/util/FisherPlane.java
+++ b/src/main/java/supersymmetry/api/util/FisherPlane.java
@@ -8,7 +8,7 @@ public class FisherPlane {
      * @param grid 3D grid with two classes of points.
      * @return  Fisher discriminant normal vector (pointing from 0s to 1s)
      */
-    public static Vec3d fisherNormal(boolean[][][] grid) {
+    public static Vec3d fisherNormal(boolean[][][] grid, boolean normalize) {
 
         int n = grid.length;
 
@@ -104,7 +104,15 @@ public class FisherPlane {
 
         Vec3d normal = new Vec3d(wx, wy, wz);
 
-        return normal.normalize();
+        if (normalize) {
+            return normal.normalize();
+        } else {
+            return normal;
+        }
+    }
+
+    public static Vec3d fisherNormal(boolean[][][] grid) {
+        return fisherNormal(grid, true);
     }
 
 }

--- a/src/main/java/supersymmetry/api/util/FisherPlane.java
+++ b/src/main/java/supersymmetry/api/util/FisherPlane.java
@@ -1,0 +1,110 @@
+package supersymmetry.api.util;
+
+import net.minecraft.util.math.Vec3d;
+
+public class FisherPlane {
+
+    /**
+     * @param grid 3D grid with two classes of points.
+     * @return  Fisher discriminant normal vector (pointing from 0s to 1s)
+     */
+    public static Vec3d fisherNormal(boolean[][][] grid) {
+
+        int n = grid.length;
+
+        double sum1x=0, sum1y=0, sum1z=0;
+        double sum0x=0, sum0y=0, sum0z=0;
+
+        int c1 = 0, c0 = 0;
+
+        // First pass: compute centroids
+        for (int x=0;x<n;x++)
+            for (int y=0;y<n;y++)
+                for (int z=0;z<n;z++) {
+
+                    if (grid[x][y][z]) {
+                        sum1x += x;
+                        sum1y += y;
+                        sum1z += z;
+                        c1++;
+                    } else {
+                        sum0x += x;
+                        sum0y += y;
+                        sum0z += z;
+                        c0++;
+                    }
+                }
+
+        if (c1 == 0 || c0 == 0)
+            return new Vec3d(0,0,0);
+
+        double m1x = sum1x / c1;
+        double m1y = sum1y / c1;
+        double m1z = sum1z / c1;
+
+        double m0x = sum0x / c0;
+        double m0y = sum0y / c0;
+        double m0z = sum0z / c0;
+
+        // Within-class scatter matrix
+        double sxx=0, sxy=0, sxz=0;
+        double syy=0, syz=0, szz=0;
+
+        for (int x=0;x<n;x++)
+            for (int y=0;y<n;y++)
+                for (int z=0;z<n;z++) {
+
+                    double dx, dy, dz;
+
+                    if (grid[x][y][z]) {
+                        dx = x - m1x;
+                        dy = y - m1y;
+                        dz = z - m1z;
+                    } else {
+                        dx = x - m0x;
+                        dy = y - m0y;
+                        dz = z - m0z;
+                    }
+
+                    sxx += dx*dx;
+                    sxy += dx*dy;
+                    sxz += dx*dz;
+                    syy += dy*dy;
+                    syz += dy*dz;
+                    szz += dz*dz;
+                }
+
+        // Invert 3x3 matrix
+        double det =
+                sxx*(syy*szz - syz*syz)
+                        - sxy*(sxy*szz - sxz*syz)
+                        + sxz*(sxy*syz - sxz*syy);
+
+        if (Math.abs(det) < 1e-12)
+            return new Vec3d(0,0,0);
+
+        double inv00 = (syy*szz - syz*syz)/det;
+        double inv01 = (sxz*syz - sxy*szz)/det;
+        double inv02 = (sxy*syz - sxz*syy)/det;
+
+        double inv11 = (sxx*szz - sxz*sxz)/det;
+        double inv12 = (sxz*sxy - sxx*syz)/det;
+
+        double inv22 = (sxx*syy - sxy*sxy)/det;
+
+        // mean difference
+        double dx = m1x - m0x;
+        double dy = m1y - m0y;
+        double dz = m1z - m0z;
+
+        // Fisher direction
+        double wx = inv00*dx + inv01*dy + inv02*dz;
+        double wy = inv01 *dx + inv11*dy + inv12*dz;
+        double wz = inv02 *dx + inv12 *dy + inv22*dz;
+
+        Vec3d normal = new Vec3d(wx, wy, wz);
+
+        return normal.normalize();
+    }
+
+}

--- a/src/main/java/supersymmetry/api/util/FisherPlane.java
+++ b/src/main/java/supersymmetry/api/util/FisherPlane.java
@@ -6,21 +6,20 @@ public class FisherPlane {
 
     /**
      * @param grid 3D grid with two classes of points.
-     * @return  Fisher discriminant normal vector (pointing from 0s to 1s)
+     * @return Fisher discriminant normal vector (pointing from 0s to 1s)
      */
     public static Vec3d fisherNormal(boolean[][][] grid, boolean normalize) {
-
         int n = grid.length;
 
-        double sum1x=0, sum1y=0, sum1z=0;
-        double sum0x=0, sum0y=0, sum0z=0;
+        double sum1x = 0, sum1y = 0, sum1z = 0;
+        double sum0x = 0, sum0y = 0, sum0z = 0;
 
         int c1 = 0, c0 = 0;
 
         // First pass: compute centroids
-        for (int x=0;x<n;x++)
-            for (int y=0;y<n;y++)
-                for (int z=0;z<n;z++) {
+        for (int x = 0; x < n; x++)
+            for (int y = 0; y < n; y++)
+                for (int z = 0; z < n; z++) {
 
                     if (grid[x][y][z]) {
                         sum1x += x;
@@ -36,7 +35,7 @@ public class FisherPlane {
                 }
 
         if (c1 == 0 || c0 == 0)
-            return new Vec3d(0,0,0);
+            return new Vec3d(0, 0, 0);
 
         double m1x = sum1x / c1;
         double m1y = sum1y / c1;
@@ -47,12 +46,12 @@ public class FisherPlane {
         double m0z = sum0z / c0;
 
         // Within-class scatter matrix
-        double sxx=0, sxy=0, sxz=0;
-        double syy=0, syz=0, szz=0;
+        double sxx = 0, sxy = 0, sxz = 0;
+        double syy = 0, syz = 0, szz = 0;
 
-        for (int x=0;x<n;x++)
-            for (int y=0;y<n;y++)
-                for (int z=0;z<n;z++) {
+        for (int x = 0; x < n; x++)
+            for (int y = 0; y < n; y++)
+                for (int z = 0; z < n; z++) {
 
                     double dx, dy, dz;
 
@@ -66,31 +65,28 @@ public class FisherPlane {
                         dz = z - m0z;
                     }
 
-                    sxx += dx*dx;
-                    sxy += dx*dy;
-                    sxz += dx*dz;
-                    syy += dy*dy;
-                    syz += dy*dz;
-                    szz += dz*dz;
+                    sxx += dx * dx;
+                    sxy += dx * dy;
+                    sxz += dx * dz;
+                    syy += dy * dy;
+                    syz += dy * dz;
+                    szz += dz * dz;
                 }
 
         // Invert 3x3 matrix
-        double det =
-                sxx*(syy*szz - syz*syz)
-                        - sxy*(sxy*szz - sxz*syz)
-                        + sxz*(sxy*syz - sxz*syy);
+        double det = sxx * (syy * szz - syz * syz) - sxy * (sxy * szz - sxz * syz) + sxz * (sxy * syz - sxz * syy);
 
         if (Math.abs(det) < 1e-12)
-            return new Vec3d(0,0,0);
+            return new Vec3d(0, 0, 0);
 
-        double inv00 = (syy*szz - syz*syz)/det;
-        double inv01 = (sxz*syz - sxy*szz)/det;
-        double inv02 = (sxy*syz - sxz*syy)/det;
+        double inv00 = (syy * szz - syz * syz) / det;
+        double inv01 = (sxz * syz - sxy * szz) / det;
+        double inv02 = (sxy * syz - sxz * syy) / det;
 
-        double inv11 = (sxx*szz - sxz*sxz)/det;
-        double inv12 = (sxz*sxy - sxx*syz)/det;
+        double inv11 = (sxx * szz - sxz * sxz) / det;
+        double inv12 = (sxz * sxy - sxx * syz) / det;
 
-        double inv22 = (sxx*syy - sxy*sxy)/det;
+        double inv22 = (sxx * syy - sxy * sxy) / det;
 
         // mean difference
         double dx = m1x - m0x;
@@ -98,9 +94,9 @@ public class FisherPlane {
         double dz = m1z - m0z;
 
         // Fisher direction
-        double wx = inv00*dx + inv01*dy + inv02*dz;
-        double wy = inv01 *dx + inv11*dy + inv12*dz;
-        double wz = inv02 *dx + inv12 *dy + inv22*dz;
+        double wx = inv00 * dx + inv01 * dy + inv02 * dz;
+        double wy = inv01 * dx + inv11 * dy + inv12 * dz;
+        double wz = inv02 * dx + inv12 * dy + inv22 * dz;
 
         Vec3d normal = new Vec3d(wx, wy, wz);
 
@@ -114,5 +110,4 @@ public class FisherPlane {
     public static Vec3d fisherNormal(boolean[][][] grid) {
         return fisherNormal(grid, true);
     }
-
 }

--- a/src/main/java/supersymmetry/common/SusyMetaEntities.java
+++ b/src/main/java/supersymmetry/common/SusyMetaEntities.java
@@ -11,10 +11,7 @@ import supersymmetry.client.renderer.handler.LanderRenderer;
 import supersymmetry.client.renderer.handler.entity.DroneRenderer;
 import supersymmetry.client.renderer.handler.entity.DropPodRenderer;
 import supersymmetry.client.renderer.handler.entity.RocketRenderer;
-import supersymmetry.common.entities.EntityDrone;
-import supersymmetry.common.entities.EntityDropPod;
-import supersymmetry.common.entities.EntityLander;
-import supersymmetry.common.entities.EntityRocket;
+import supersymmetry.common.entities.*;
 
 public class SusyMetaEntities {
 
@@ -27,6 +24,8 @@ public class SusyMetaEntities {
                 "Rocket", 3, Supersymmetry.instance, 64, 3, true);
         EntityRegistry.registerModEntity(new ResourceLocation(Supersymmetry.MODID, "lander"), EntityLander.class,
                 "Lander", 4, Supersymmetry.instance, 64, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Supersymmetry.MODID, "explosion"), EntityExplosion.class,
+                "Explosion", 5, Supersymmetry.instance, 64, 3, false);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/supersymmetry/common/entities/EntityExplosion.java
+++ b/src/main/java/supersymmetry/common/entities/EntityExplosion.java
@@ -14,7 +14,6 @@ import supersymmetry.api.util.FisherPlane;
 import supersymmetry.client.renderer.particles.SusyParticleSmokeLarge;
 
 import java.util.Random;
-import java.util.function.Predicate;
 
 public class EntityExplosion extends Entity {
 
@@ -23,6 +22,8 @@ public class EntityExplosion extends Entity {
     private Vec3d fisherNormal;
     private static final Random rnd = new Random();
     private static final double v0 = 1d;
+
+    private static final int delay = 0;
 
     public EntityExplosion(World worldIn) {
         super(worldIn);
@@ -61,27 +62,27 @@ public class EntityExplosion extends Entity {
             fillGrid();
         } else if (this.ticksExisted == 3) {
             this.fisherNormal = FisherPlane.fisherNormal(grid);
-        } else if (this.ticksExisted == 100) {
+        } else if (this.ticksExisted == 4 + delay) {
             if (world.isRemote) {
                 spawnExplosionParticles();
             } else {
                 explode();
             }
-        } else if (this.ticksExisted >= 100 && this.ticksExisted <= 110 && world.isRemote) {
+        } else if (this.ticksExisted >= 4 + delay && this.ticksExisted <= 14 + delay && world.isRemote) {
             for (EntityPlayer player : world.playerEntities) {
                 if (player != null && getDistanceSq(player) < 1024) {
                     player.rotationPitch += 1.25f*(rnd.nextFloat() - 0.5f);
                     player.rotationYaw += 1.25f*(rnd.nextFloat() - 0.5f);
                 }
             }
-        } else if (this.ticksExisted == 111) {
+        } else if (this.ticksExisted == 15 + delay) {
             this.setDead();
         }
 
     }
 
     protected void explode() {
-        this.world.createExplosion(null, this.posX, this.posY, this.posZ, 5f, true);
+        this.world.createExplosion(null, this.posX, this.posY, this.posZ, this.power, true);
     }
 
     @SideOnly(Side.CLIENT)
@@ -93,8 +94,9 @@ public class EntityExplosion extends Entity {
     @SideOnly(Side.CLIENT)
     protected void spawnExplosionParticles() {
         double v0scaled;
-        for (int i = 0; i < 25; i++) {
-            v0scaled = v0 * rnd.nextFloat() * 2f;
+        int powerSq = this.power * this.power;
+        for (int i = 0; i < powerSq; i++) {
+            v0scaled = v0 * rnd.nextFloat() * 1.5f;
             SusyParticleSmokeLarge smoke = new SusyParticleSmokeLarge(
                     this.world,
                     this.posX + this.power * (rnd.nextFloat() - 0.5) * 0.5,

--- a/src/main/java/supersymmetry/common/entities/EntityExplosion.java
+++ b/src/main/java/supersymmetry/common/entities/EntityExplosion.java
@@ -1,5 +1,7 @@
 package supersymmetry.common.entities;
 
+import java.util.Random;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -10,10 +12,9 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
 import supersymmetry.api.util.FisherPlane;
 import supersymmetry.client.renderer.particles.SusyParticleSmokeLarge;
-
-import java.util.Random;
 
 public class EntityExplosion extends Entity {
 
@@ -40,20 +41,18 @@ public class EntityExplosion extends Entity {
         this.power = power;
     }
 
-
     @Override
-    protected void entityInit() {
-
-    }
+    protected void entityInit() {}
 
     @Override
     public double getDistanceSq(Entity entity) {
-        return (this.posX - entity.posX)*(this.posX - entity.posX) + (this.posY - entity.posY)*(this.posY - entity.posY) + (this.posZ - entity.posZ)*(this.posZ - entity.posZ);
+        return (this.posX - entity.posX) * (this.posX - entity.posX) +
+                (this.posY - entity.posY) * (this.posY - entity.posY) +
+                (this.posZ - entity.posZ) * (this.posZ - entity.posZ);
     }
 
     @Override
     public void onUpdate() {
-
         super.onUpdate();
 
         if (this.ticksExisted == 1) {
@@ -71,14 +70,13 @@ public class EntityExplosion extends Entity {
         } else if (this.ticksExisted >= 4 + delay && this.ticksExisted <= 14 + delay && world.isRemote) {
             for (EntityPlayer player : world.playerEntities) {
                 if (player != null && getDistanceSq(player) < 1024) {
-                    player.rotationPitch += 1.25f*(rnd.nextFloat() - 0.5f);
-                    player.rotationYaw += 1.25f*(rnd.nextFloat() - 0.5f);
+                    player.rotationPitch += 1.25f * (rnd.nextFloat() - 0.5f);
+                    player.rotationYaw += 1.25f * (rnd.nextFloat() - 0.5f);
                 }
             }
         } else if (this.ticksExisted == 15 + delay) {
             this.setDead();
         }
-
     }
 
     protected void explode() {
@@ -104,14 +102,14 @@ public class EntityExplosion extends Entity {
                     this.posZ + this.power * (rnd.nextFloat() - 0.5) * 0.5,
                     v0scaled * (this.fisherNormal.x + 0.5 * (rnd.nextFloat() - 0.5)),
                     v0scaled * (this.fisherNormal.y + 0.5 * (rnd.nextFloat() - 0.5)),
-                    v0scaled * (this.fisherNormal.z + 0.5 * (rnd.nextFloat() - 0.5))
-            );
+                    v0scaled * (this.fisherNormal.z + 0.5 * (rnd.nextFloat() - 0.5)));
             Minecraft.getMinecraft().effectRenderer.addEffect(smoke);
         }
     }
 
     protected void fillGrid() {
-        BlockPos.MutableBlockPos p = new BlockPos.MutableBlockPos((int)this.posX - power, (int)this.posY - power, (int)this.posZ - power);
+        BlockPos.MutableBlockPos p = new BlockPos.MutableBlockPos((int) this.posX - power, (int) this.posY - power,
+                (int) this.posZ - power);
         int d = 2 * power;
         for (int i = 0; i < d; i++) {
             for (int j = 0; j < d; j++) {
@@ -124,12 +122,8 @@ public class EntityExplosion extends Entity {
     }
 
     @Override
-    protected void readEntityFromNBT(NBTTagCompound compound) {
-
-    }
+    protected void readEntityFromNBT(NBTTagCompound compound) {}
 
     @Override
-    protected void writeEntityToNBT(NBTTagCompound compound) {
-
-    }
+    protected void writeEntityToNBT(NBTTagCompound compound) {}
 }

--- a/src/main/java/supersymmetry/common/entities/EntityExplosion.java
+++ b/src/main/java/supersymmetry/common/entities/EntityExplosion.java
@@ -7,6 +7,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import supersymmetry.api.SusyLog;
 import supersymmetry.api.util.FisherPlane;
 import supersymmetry.client.renderer.particles.SusyParticleSmokeLarge;
@@ -59,26 +61,37 @@ public class EntityExplosion extends Entity {
         } else if (this.ticksExisted == 100) {
             //SusyLog.logger.info("Boom");
             explode();
-            spawnExplosionParticles();
+            if (world.isRemote) {
+                spawnExplosionParticles();
+            }
             this.setDead();
         }
 
     }
 
     protected void explode() {
-
+        this.world.createExplosion(null, this.posX, this.posY, this.posZ, 5f, true);
     }
 
+    @SideOnly(Side.CLIENT)
+    @Override
+    public boolean isInRangeToRenderDist(double distance) {
+        return false;
+    }
+
+    @SideOnly(Side.CLIENT)
     protected void spawnExplosionParticles() {
-        for (int i = 0; i < 20; i++) {
+        double v0scaled;
+        for (int i = 0; i < 25; i++) {
+            v0scaled = v0 * rnd.nextFloat() * 2f;
             SusyParticleSmokeLarge smoke = new SusyParticleSmokeLarge(
                     this.world,
-                    this.posX,
-                    this.posY,
-                    this.posZ,
-                    v0 * (this.fisherNormal.x + 0.5 * (rnd.nextFloat() - 0.5)),
-                    v0 * (this.fisherNormal.y + 0.5 * (rnd.nextFloat() - 0.5)),
-                    v0 * (this.fisherNormal.z + 0.5 * (rnd.nextFloat() - 0.5))
+                    this.posX + this.power * (rnd.nextFloat() - 0.5) * 0.5,
+                    this.posY + this.power * (rnd.nextFloat() - 0.5) * 0.5,
+                    this.posZ + this.power * (rnd.nextFloat() - 0.5) * 0.5,
+                    v0scaled * (this.fisherNormal.x + 0.5 * (rnd.nextFloat() - 0.5)),
+                    v0scaled * (this.fisherNormal.y + 0.5 * (rnd.nextFloat() - 0.5)),
+                    v0scaled * (this.fisherNormal.z + 0.5 * (rnd.nextFloat() - 0.5))
             );
             Minecraft.getMinecraft().effectRenderer.addEffect(smoke);
         }

--- a/src/main/java/supersymmetry/common/entities/EntityExplosion.java
+++ b/src/main/java/supersymmetry/common/entities/EntityExplosion.java
@@ -2,8 +2,10 @@ package supersymmetry.common.entities;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -26,6 +28,14 @@ public class EntityExplosion extends Entity {
     public EntityExplosion(World worldIn) {
         super(worldIn);
         this.power = 5;
+        this.setEntityBoundingBox(new AxisAlignedBB(
+                this.posX - 3 * this.power,
+                this.posY - 3 * this.power,
+                this.posZ - 3 * this.power,
+                this.posX + 3 * this.power,
+                this.posY + 3 * this.power,
+                this.posZ + 3 * this.power
+        ));
     }
 
     public EntityExplosion(World worldIn, double x, double y, double z) {
@@ -41,7 +51,14 @@ public class EntityExplosion extends Entity {
 
     @Override
     protected void entityInit() {
-
+        this.setEntityBoundingBox(new AxisAlignedBB(
+                this.posX - 3 * this.power,
+                this.posY - 3 * this.power,
+                this.posZ - 3 * this.power,
+                this.posX + 3 * this.power,
+                this.posY + 3 * this.power,
+                this.posZ + 3 * this.power
+        ));
     }
 
     @Override
@@ -64,6 +81,12 @@ public class EntityExplosion extends Entity {
             if (world.isRemote) {
                 spawnExplosionParticles();
             }
+        } else if (this.ticksExisted >= 100 && this.ticksExisted <= 110 && world.isRemote) {
+            for (EntityPlayer player : world.getEntitiesWithinAABB(EntityPlayer.class, this.getEntityBoundingBox())) {
+                player.rotationPitch += (rnd.nextFloat() - 0.5f);
+                player.rotationYaw += (rnd.nextFloat() - 0.5f);
+            }
+        } else if (this.ticksExisted == 111) {
             this.setDead();
         }
 

--- a/src/main/java/supersymmetry/common/entities/EntityExplosion.java
+++ b/src/main/java/supersymmetry/common/entities/EntityExplosion.java
@@ -5,13 +5,11 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import supersymmetry.api.SusyLog;
 import supersymmetry.api.util.FisherPlane;
 import supersymmetry.client.renderer.particles.SusyParticleSmokeLarge;
 
@@ -28,14 +26,6 @@ public class EntityExplosion extends Entity {
     public EntityExplosion(World worldIn) {
         super(worldIn);
         this.power = 5;
-        this.setEntityBoundingBox(new AxisAlignedBB(
-                this.posX - 3 * this.power,
-                this.posY - 3 * this.power,
-                this.posZ - 3 * this.power,
-                this.posX + 3 * this.power,
-                this.posY + 3 * this.power,
-                this.posZ + 3 * this.power
-        ));
     }
 
     public EntityExplosion(World worldIn, double x, double y, double z) {
@@ -51,14 +41,7 @@ public class EntityExplosion extends Entity {
 
     @Override
     protected void entityInit() {
-        this.setEntityBoundingBox(new AxisAlignedBB(
-                this.posX - 3 * this.power,
-                this.posY - 3 * this.power,
-                this.posZ - 3 * this.power,
-                this.posX + 3 * this.power,
-                this.posY + 3 * this.power,
-                this.posZ + 3 * this.power
-        ));
+
     }
 
     @Override
@@ -69,17 +52,14 @@ public class EntityExplosion extends Entity {
         if (this.ticksExisted == 1) {
             this.grid = new boolean[2 * this.power][2 * this.power][2 * this.power];
         } else if (this.ticksExisted == 2) {
-            //SusyLog.logger.info("Filling grid");
             fillGrid();
         } else if (this.ticksExisted == 3) {
-            //SusyLog.logger.info("Computing fisher");
             this.fisherNormal = FisherPlane.fisherNormal(grid);
-            //SusyLog.logger.info(fisherNormal);
         } else if (this.ticksExisted == 100) {
-            //SusyLog.logger.info("Boom");
-            explode();
             if (world.isRemote) {
                 spawnExplosionParticles();
+            } else {
+                explode();
             }
         } else if (this.ticksExisted >= 100 && this.ticksExisted <= 110 && world.isRemote) {
             for (EntityPlayer player : world.getEntitiesWithinAABB(EntityPlayer.class, this.getEntityBoundingBox())) {
@@ -123,15 +103,10 @@ public class EntityExplosion extends Entity {
     protected void fillGrid() {
         BlockPos.MutableBlockPos p = new BlockPos.MutableBlockPos((int)this.posX - power, (int)this.posY - power, (int)this.posZ - power);
         int d = 2 * power;
-        //SusyLog.logger.info(d);
-        //SusyLog.logger.info(grid.length);
         for (int i = 0; i < d; i++) {
             for (int j = 0; j < d; j++) {
                 for (int k = 0; k < d; k++) {
                     BlockPos newPos = p.add(i, j, k);
-                    //SusyLog.logger.info(i);
-                    //SusyLog.logger.info(j);
-                    //SusyLog.logger.info(k);
                     grid[i][j][k] = world.getBlockState(newPos) == Blocks.AIR.getDefaultState();
                 }
             }

--- a/src/main/java/supersymmetry/common/entities/EntityExplosion.java
+++ b/src/main/java/supersymmetry/common/entities/EntityExplosion.java
@@ -14,6 +14,7 @@ import supersymmetry.api.util.FisherPlane;
 import supersymmetry.client.renderer.particles.SusyParticleSmokeLarge;
 
 import java.util.Random;
+import java.util.function.Predicate;
 
 public class EntityExplosion extends Entity {
 
@@ -45,6 +46,11 @@ public class EntityExplosion extends Entity {
     }
 
     @Override
+    public double getDistanceSq(Entity entity) {
+        return (this.posX - entity.posX)*(this.posX - entity.posX) + (this.posY - entity.posY)*(this.posY - entity.posY) + (this.posZ - entity.posZ)*(this.posZ - entity.posZ);
+    }
+
+    @Override
     public void onUpdate() {
 
         super.onUpdate();
@@ -62,9 +68,11 @@ public class EntityExplosion extends Entity {
                 explode();
             }
         } else if (this.ticksExisted >= 100 && this.ticksExisted <= 110 && world.isRemote) {
-            for (EntityPlayer player : world.getEntitiesWithinAABB(EntityPlayer.class, this.getEntityBoundingBox())) {
-                player.rotationPitch += (rnd.nextFloat() - 0.5f);
-                player.rotationYaw += (rnd.nextFloat() - 0.5f);
+            for (EntityPlayer player : world.playerEntities) {
+                if (player != null && getDistanceSq(player) < 1024) {
+                    player.rotationPitch += 1.25f*(rnd.nextFloat() - 0.5f);
+                    player.rotationYaw += 1.25f*(rnd.nextFloat() - 0.5f);
+                }
             }
         } else if (this.ticksExisted == 111) {
             this.setDead();

--- a/src/main/java/supersymmetry/common/entities/EntityExplosion.java
+++ b/src/main/java/supersymmetry/common/entities/EntityExplosion.java
@@ -1,0 +1,114 @@
+package supersymmetry.common.entities;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.init.Blocks;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import supersymmetry.api.SusyLog;
+import supersymmetry.api.util.FisherPlane;
+import supersymmetry.client.renderer.particles.SusyParticleSmokeLarge;
+
+import java.util.Random;
+
+public class EntityExplosion extends Entity {
+
+    private int power;
+    private boolean[][][] grid;
+    private Vec3d fisherNormal;
+    private static final Random rnd = new Random();
+    private static final double v0 = 1d;
+
+    public EntityExplosion(World worldIn) {
+        super(worldIn);
+        this.power = 5;
+    }
+
+    public EntityExplosion(World worldIn, double x, double y, double z) {
+        this(worldIn);
+        this.setPosition(x, y, z);
+    }
+
+    public EntityExplosion(World worldIn, double x, double y, double z, int power) {
+        this(worldIn, x, y, z);
+        this.power = power;
+    }
+
+
+    @Override
+    protected void entityInit() {
+
+    }
+
+    @Override
+    public void onUpdate() {
+
+        super.onUpdate();
+
+        if (this.ticksExisted == 1) {
+            this.grid = new boolean[2 * this.power][2 * this.power][2 * this.power];
+        } else if (this.ticksExisted == 2) {
+            //SusyLog.logger.info("Filling grid");
+            fillGrid();
+        } else if (this.ticksExisted == 3) {
+            //SusyLog.logger.info("Computing fisher");
+            this.fisherNormal = FisherPlane.fisherNormal(grid);
+            //SusyLog.logger.info(fisherNormal);
+        } else if (this.ticksExisted == 100) {
+            //SusyLog.logger.info("Boom");
+            explode();
+            spawnExplosionParticles();
+            this.setDead();
+        }
+
+    }
+
+    protected void explode() {
+
+    }
+
+    protected void spawnExplosionParticles() {
+        for (int i = 0; i < 20; i++) {
+            SusyParticleSmokeLarge smoke = new SusyParticleSmokeLarge(
+                    this.world,
+                    this.posX,
+                    this.posY,
+                    this.posZ,
+                    v0 * (this.fisherNormal.x + 0.5 * (rnd.nextFloat() - 0.5)),
+                    v0 * (this.fisherNormal.y + 0.5 * (rnd.nextFloat() - 0.5)),
+                    v0 * (this.fisherNormal.z + 0.5 * (rnd.nextFloat() - 0.5))
+            );
+            Minecraft.getMinecraft().effectRenderer.addEffect(smoke);
+        }
+    }
+
+    protected void fillGrid() {
+        BlockPos.MutableBlockPos p = new BlockPos.MutableBlockPos((int)this.posX - power, (int)this.posY - power, (int)this.posZ - power);
+        int d = 2 * power;
+        //SusyLog.logger.info(d);
+        //SusyLog.logger.info(grid.length);
+        for (int i = 0; i < d; i++) {
+            for (int j = 0; j < d; j++) {
+                for (int k = 0; k < d; k++) {
+                    BlockPos newPos = p.add(i, j, k);
+                    //SusyLog.logger.info(i);
+                    //SusyLog.logger.info(j);
+                    //SusyLog.logger.info(k);
+                    grid[i][j][k] = world.getBlockState(newPos) == Blocks.AIR.getDefaultState();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void readEntityFromNBT(NBTTagCompound compound) {
+
+    }
+
+    @Override
+    protected void writeEntityToNBT(NBTTagCompound compound) {
+
+    }
+}


### PR DESCRIPTION
Adds nicer looking explosions with improved particles.
Implementation details:

- Uses [Fisher's Linear Discriminant](https://en.wikipedia.org/wiki/Linear_discriminant_analysis#Fisher's_linear_discriminant) to determine where blocks are.
- Uses normal vector from discriminant to determine in which direction to shoot particles.
- Amount of particles depends on explosion power.
- Math is spread across multiple ticks to mitigate lag spikes
- Applies camera shake to nearby players (within a fixed 32 block distance for now)

Possible improvements:
- Overall better damage algorithm (for now still uses vanilla one)
- Better sound
- Further refinements in particle effects depending on explosion power and geometry around th explosion

As a starter I think we can merge this so people can play around with it and see how well the general idea works.