### PR TITLE
Ol anti air mixin

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -89,6 +89,10 @@ dependencies {
     compileOnly rfg.deobf('curse.maven:project-red-core-228702:2745545')
 
     runtimeOnly rfg.deobf("curse.maven:serverutil-282484:2503313")
+
+    //ICBM
+    //temporary dep, will replace once we have our own missiles
+    implementation rfg.deobf("curse.maven:icbm-244451:6496624")
     // # Optional dependencies. Uncomment the ones you need
 //    runtimeOnlyNonPublishable rfg.deobf('curse.maven:the-beneath-254629:3425551')
 //    runtimeOnlyNonPublishable rfg.deobf('curse.maven:realistic-terrain-generation-unofficial-648514:4404814')

--- a/src/main/java/supersymmetry/api/mixin/IDropPodRadar.java
+++ b/src/main/java/supersymmetry/api/mixin/IDropPodRadar.java
@@ -1,0 +1,8 @@
+package supersymmetry.api.mixin;
+
+import supersymmetry.common.entities.EntityDropPod;
+import java.util.List;
+
+public interface IDropPodRadar {
+    List<EntityDropPod> susy$getIncomingDropPods();
+}

--- a/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
+++ b/src/main/java/supersymmetry/mixins/SuSyLateMixinLoader.java
@@ -21,7 +21,8 @@ public class SuSyLateMixinLoader implements ILateMixinLoader {
             "fluidlogged_api",
             "littletiles",
             "celeritas",
-            "projectred-core");
+            "projectred-core",
+            "icbmclassic");
 
     @Override
     public List<String> getMixinConfigs() {

--- a/src/main/java/supersymmetry/mixins/icbmclassic/RadarRenderDataMixin.java
+++ b/src/main/java/supersymmetry/mixins/icbmclassic/RadarRenderDataMixin.java
@@ -1,0 +1,34 @@
+package supersymmetry.mixins.icbmclassic;
+
+import icbm.classic.content.blocks.radarstation.TileRadarStation;
+import icbm.classic.content.blocks.radarstation.data.RadarDotType;
+import icbm.classic.content.blocks.radarstation.data.RadarRenderData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import supersymmetry.api.mixin.IDropPodRadar;
+import supersymmetry.common.entities.EntityDropPod;
+
+@Mixin(value = RadarRenderData.class, remap = false)
+public abstract class RadarRenderDataMixin {
+
+    @Shadow
+    private TileRadarStation host;
+
+    @Shadow
+    public abstract void addDot(double ex, double ez, RadarDotType type);
+
+    @Inject(method = "update()V", at = @At("TAIL"), remap = false)
+    private void supersymmetry$addDropPodDots(CallbackInfo ci) {
+        if (!(host instanceof IDropPodRadar)) return;
+
+        for (EntityDropPod pod : ((IDropPodRadar) host).susy$getIncomingDropPods()) {
+            if (pod.isEntityAlive()) {
+                // INCOMING = red dot, same as missiles heading toward the radar
+                addDot(pod.posX, pod.posZ, RadarDotType.INCOMING);
+            }
+        }
+    }
+}

--- a/src/main/java/supersymmetry/mixins/icbmclassic/SAMTargetDataMixin.java
+++ b/src/main/java/supersymmetry/mixins/icbmclassic/SAMTargetDataMixin.java
@@ -1,0 +1,84 @@
+package supersymmetry.mixins.icbmclassic;
+
+import icbm.classic.content.missile.entity.EntityMissile;
+import icbm.classic.content.missile.entity.anti.EntitySurfaceToAirMissile;
+import icbm.classic.content.missile.entity.anti.SAMTargetData;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import supersymmetry.api.SusyLog;
+import supersymmetry.common.entities.EntityDropPod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mixin(value = SAMTargetData.class, remap = false)
+public abstract class SAMTargetDataMixin {
+
+    static {
+        SusyLog.logger.info("[SUSY MIXIN] SAMTargetDataMixin class loaded");
+    }
+
+    @Shadow @Final
+    private EntitySurfaceToAirMissile host;
+
+    @Shadow
+    protected abstract AxisAlignedBB targetArea();
+
+    @Inject(
+            method = "getValidTargets",
+            at = @At("HEAD"),
+            cancellable = true,
+            remap = false
+    )
+    private void supersymmetry$getValidTargets(CallbackInfoReturnable<List<Entity>> cir) {
+
+        SusyLog.logger.info("[SUSY MIXIN] getValidTargets injected");
+
+        World world = host.world;
+
+        List<Entity> targets = new ArrayList<>();
+
+        List<EntityMissile> missiles = world.getEntitiesWithinAABB(
+                EntityMissile.class,
+                targetArea()
+        );
+
+        SusyLog.logger.info("[SUSY MIXIN] missiles found: {}", missiles.size());
+
+        targets.addAll(missiles);
+
+        List<EntityDropPod> pods = world.getEntitiesWithinAABB(
+                EntityDropPod.class,
+                targetArea()
+        );
+
+        SusyLog.logger.info("[SUSY MIXIN] drop pods found: {}", pods.size());
+
+        targets.addAll(pods);
+
+        cir.setReturnValue(targets);
+    }
+
+    @Inject(
+            method = "isValid(Lnet/minecraft/entity/Entity;)Z",
+            at = @At("HEAD"),
+            cancellable = true,
+            remap = false
+    )
+    private void supersymmetry$isValid(Entity entity, CallbackInfoReturnable<Boolean> cir) {
+
+        SusyLog.logger.info("[SUSY MIXIN] isValid injected: {}", entity);
+
+        if (entity instanceof EntityDropPod) {
+            SusyLog.logger.info("[SUSY MIXIN] accepting drop pod");
+            cir.setReturnValue(entity.isEntityAlive());
+        }
+    }
+}

--- a/src/main/java/supersymmetry/mixins/icbmclassic/SAMTargetDataMixin.java
+++ b/src/main/java/supersymmetry/mixins/icbmclassic/SAMTargetDataMixin.java
@@ -12,7 +12,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import supersymmetry.api.SusyLog;
 import supersymmetry.common.entities.EntityDropPod;
 
 import java.util.ArrayList;
@@ -20,11 +19,6 @@ import java.util.List;
 
 @Mixin(value = SAMTargetData.class, remap = false)
 public abstract class SAMTargetDataMixin {
-
-    static {
-        SusyLog.logger.info("[SUSY MIXIN] SAMTargetDataMixin class loaded");
-    }
-
     @Shadow @Final
     private EntitySurfaceToAirMissile host;
 
@@ -38,9 +32,6 @@ public abstract class SAMTargetDataMixin {
             remap = false
     )
     private void supersymmetry$getValidTargets(CallbackInfoReturnable<List<Entity>> cir) {
-
-        SusyLog.logger.info("[SUSY MIXIN] getValidTargets injected");
-
         World world = host.world;
 
         List<Entity> targets = new ArrayList<>();
@@ -50,16 +41,12 @@ public abstract class SAMTargetDataMixin {
                 targetArea()
         );
 
-        SusyLog.logger.info("[SUSY MIXIN] missiles found: {}", missiles.size());
-
         targets.addAll(missiles);
 
         List<EntityDropPod> pods = world.getEntitiesWithinAABB(
                 EntityDropPod.class,
                 targetArea()
         );
-
-        SusyLog.logger.info("[SUSY MIXIN] drop pods found: {}", pods.size());
 
         targets.addAll(pods);
 
@@ -73,11 +60,7 @@ public abstract class SAMTargetDataMixin {
             remap = false
     )
     private void supersymmetry$isValid(Entity entity, CallbackInfoReturnable<Boolean> cir) {
-
-        SusyLog.logger.info("[SUSY MIXIN] isValid injected: {}", entity);
-
         if (entity instanceof EntityDropPod) {
-            SusyLog.logger.info("[SUSY MIXIN] accepting drop pod");
             cir.setReturnValue(entity.isEntityAlive());
         }
     }

--- a/src/main/java/supersymmetry/mixins/icbmclassic/TileRadarStationMixin.java
+++ b/src/main/java/supersymmetry/mixins/icbmclassic/TileRadarStationMixin.java
@@ -1,0 +1,94 @@
+package supersymmetry.mixins.icbmclassic;
+
+import icbm.classic.content.blocks.radarstation.EnumRadarState;
+import icbm.classic.content.blocks.radarstation.TileRadarStation;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import supersymmetry.api.SusyLog;
+import supersymmetry.api.mixin.IDropPodRadar;
+import supersymmetry.common.entities.EntityDropPod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mixin(value = TileRadarStation.class, remap = false)
+public abstract class TileRadarStationMixin implements IDropPodRadar {
+
+    static {
+        SusyLog.logger.info("[SUSY MIXIN] TileRadarStationMixin class loaded");
+    }
+
+    @Shadow
+    private int detectionRange;
+
+    @Unique
+    private final List<EntityDropPod> susy$incomingDropPods = new ArrayList<>();
+
+    @Override
+    public List<EntityDropPod> susy$getIncomingDropPods() {
+        return susy$incomingDropPods;
+    }
+
+    @Inject(method = "doScan()V", at = @At("TAIL"), remap = false)
+    private void supersymmetry$scanDropPods(CallbackInfo ci) {
+        susy$incomingDropPods.clear();
+
+        TileEntity self = (TileEntity)(Object) this;
+        BlockPos pos = self.getPos();
+        net.minecraft.world.World world = self.getWorld();
+        if (world == null) return;
+
+        Vec3d radarPos = new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
+
+        AxisAlignedBB area = new AxisAlignedBB(
+                pos.getX() - detectionRange, pos.getY() - detectionRange, pos.getZ() - detectionRange,
+                pos.getX() + detectionRange, pos.getY() + detectionRange, pos.getZ() + detectionRange
+        );
+
+        List<EntityDropPod> pods = world.getEntitiesWithinAABB(EntityDropPod.class, area);
+        SusyLog.logger.info("[SUSY MIXIN] doScan found {} drop pods", pods.size());
+
+        for (EntityDropPod pod : pods) {
+            if (!pod.isEntityAlive()) continue;
+            Vec3d podPos = pod.getPositionVector();
+            double currentDistance = podPos.distanceTo(radarPos);
+            double nextDistance = podPos.add(pod.motionX, pod.motionY, pod.motionZ).distanceTo(radarPos);
+            if (nextDistance < currentDistance) {
+                susy$incomingDropPods.add(pod);
+                SusyLog.logger.info("[SUSY MIXIN] drop pod incoming at {}, {}, {}", pod.posX, pod.posY, pod.posZ);
+            }
+        }
+    }
+
+    @Inject(method = "hasIncomingMissiles()Z", at = @At("RETURN"), remap = false, cancellable = true)
+    private void supersymmetry$hasIncomingMissiles(CallbackInfoReturnable<Boolean> cir) {
+        if (!susy$incomingDropPods.isEmpty()) {
+            cir.setReturnValue(true);
+        }
+    }
+
+    @Inject(method = "getRadarState()Licbm/classic/content/blocks/radarstation/EnumRadarState;", at = @At("RETURN"), remap = false, cancellable = true)
+    private void supersymmetry$getRadarState(CallbackInfoReturnable<EnumRadarState> cir) {
+        // Only upgrade the state, never downgrade
+        if (!susy$incomingDropPods.isEmpty() && cir.getReturnValue() != EnumRadarState.DANGER) {
+            cir.setReturnValue(EnumRadarState.DANGER);
+        }
+    }
+
+    @Inject(method = "getStrongRedstonePower(Lnet/minecraft/util/EnumFacing;)I", at = @At("RETURN"), remap = false, cancellable = true)
+    private void supersymmetry$redstonePower(EnumFacing side, CallbackInfoReturnable<Integer> cir) {
+        if (!susy$incomingDropPods.isEmpty()) {
+            cir.setReturnValue(Math.min(15, cir.getReturnValue() + susy$incomingDropPods.size()));
+        }
+    }
+}

--- a/src/main/java/supersymmetry/mixins/icbmclassic/TileRadarStationMixin.java
+++ b/src/main/java/supersymmetry/mixins/icbmclassic/TileRadarStationMixin.java
@@ -14,7 +14,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import supersymmetry.api.SusyLog;
 import supersymmetry.api.mixin.IDropPodRadar;
 import supersymmetry.common.entities.EntityDropPod;
 
@@ -23,10 +22,6 @@ import java.util.List;
 
 @Mixin(value = TileRadarStation.class, remap = false)
 public abstract class TileRadarStationMixin implements IDropPodRadar {
-
-    static {
-        SusyLog.logger.info("[SUSY MIXIN] TileRadarStationMixin class loaded");
-    }
 
     @Shadow
     private int detectionRange;
@@ -56,7 +51,6 @@ public abstract class TileRadarStationMixin implements IDropPodRadar {
         );
 
         List<EntityDropPod> pods = world.getEntitiesWithinAABB(EntityDropPod.class, area);
-        SusyLog.logger.info("[SUSY MIXIN] doScan found {} drop pods", pods.size());
 
         for (EntityDropPod pod : pods) {
             if (!pod.isEntityAlive()) continue;
@@ -65,7 +59,6 @@ public abstract class TileRadarStationMixin implements IDropPodRadar {
             double nextDistance = podPos.add(pod.motionX, pod.motionY, pod.motionZ).distanceTo(radarPos);
             if (nextDistance < currentDistance) {
                 susy$incomingDropPods.add(pod);
-                SusyLog.logger.info("[SUSY MIXIN] drop pod incoming at {}, {}, {}", pod.posX, pod.posY, pod.posZ);
             }
         }
     }

--- a/src/main/resources/mixins.susy.icbmclassic.json
+++ b/src/main/resources/mixins.susy.icbmclassic.json
@@ -1,0 +1,11 @@
+{
+  "package": "supersymmetry.mixins.icbmclassic",
+  "refmap": "mixins.susy.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "SAMTargetDataMixin",
+    "TileRadarStationMixin"
+  ]
+}

--- a/src/main/resources/mixins.susy.icbmclassic.json
+++ b/src/main/resources/mixins.susy.icbmclassic.json
@@ -6,6 +6,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "SAMTargetDataMixin",
-    "TileRadarStationMixin"
+    "TileRadarStationMixin",
+    "RadarRenderDataMixin"
   ]
 }


### PR DESCRIPTION
This mixin makes it possible for our drop pods to be targetted by the ICBM radar block, and tracked by their anti-air missiles.
If it's bothersome we can remove some of the logging before merging