### PR TITLE
Add LV-EV 64A Substation hatches

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
+++ b/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
@@ -23,6 +23,7 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockTurbineCasing;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityEnergyHatch;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntitySubstationEnergyHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiFluidHatch;
 import gregtech.common.metatileentities.storage.MetaTileEntityCrate;
 import gregtech.common.metatileentities.storage.MetaTileEntityDrum;
@@ -155,6 +156,12 @@ public class SuSyMetaTileEntities {
 
     public static MetaTileEntityEnergyHatch[] NEW_ENERGY_OUTPUT_HATCH_4A = new MetaTileEntityEnergyHatch[3];
     public static MetaTileEntityEnergyHatch[] NEW_ENERGY_OUTPUT_HATCH_16A = new MetaTileEntityEnergyHatch[4];
+
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[3];
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[4];
+
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[3];
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[4];
 
     public static MetaTileEntityPrimitiveMudPump PRIMITIVE_MUD_PUMP;
 
@@ -526,6 +533,19 @@ public class SuSyMetaTileEntities {
                 new SusyMetaTileEntityEnergyHatch(susyId("energy_hatch.output_16a.hv"), 3, 16, true));
         NEW_ENERGY_OUTPUT_HATCH_16A[3] = registerMetaTileEntity(16006,
                 new SusyMetaTileEntityEnergyHatch(susyId("energy_hatch.output_16a.ev"), 4, 16, true));
+
+        NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A[0] = registerMetaTileEntity(16100,
+                new SusyMetaTileEntitySubstationEnergyHatch(susyId("substation_energy_hatch.output_64a.lv"), 1, 64, true));
+        NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A[1] = registerMetaTileEntity(16101,
+                new SusyMetaTileEntitySubstationEnergyHatch(susyId("substation_energy_hatch.output_64a.mv"), 2, 64, true));
+        NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A[2] = registerMetaTileEntity(16102,
+                new SusyMetaTileEntitySubstationEnergyHatch(susyId("substation_energy_hatch.output_64a.hv"), 3, 64, true));
+        NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A[3] = registerMetaTileEntity(16103,
+                new SusyMetaTileEntitySubstationEnergyHatch(susyId("substation_energy_hatch.output_64a.ev"), 4, 64, true));
+
+        NEW_SUBSTATION_ENERGY_INPUT_HATCH_64A[3] = registerMetaTileEntity(16109,
+                new SusyMetaTileEntitySubstationEnergyHatch(susyId("substation_energy_hatch.input_64a.ev"), 4, 64, false));
+
 
         INCINERATOR[0] = registerMetaTileEntity(16500,
                 new MetaTileEntityIncinerator(susyId("incinerator.lv"), 1, 20, 10));

--- a/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
+++ b/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
@@ -158,10 +158,10 @@ public class SuSyMetaTileEntities {
     public static MetaTileEntityEnergyHatch[] NEW_ENERGY_OUTPUT_HATCH_16A = new MetaTileEntityEnergyHatch[4];
 
     public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[4];
-    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[4];
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[5];
 
     public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[4];
-    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[4];
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[5];
 
     public static MetaTileEntityPrimitiveMudPump PRIMITIVE_MUD_PUMP;
 

--- a/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
+++ b/src/main/java/supersymmetry/common/metatileentities/SuSyMetaTileEntities.java
@@ -157,10 +157,10 @@ public class SuSyMetaTileEntities {
     public static MetaTileEntityEnergyHatch[] NEW_ENERGY_OUTPUT_HATCH_4A = new MetaTileEntityEnergyHatch[3];
     public static MetaTileEntityEnergyHatch[] NEW_ENERGY_OUTPUT_HATCH_16A = new MetaTileEntityEnergyHatch[4];
 
-    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[3];
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[4];
     public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[4];
 
-    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[3];
+    public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_64A = new MetaTileEntitySubstationEnergyHatch[4];
     public static MetaTileEntityEnergyHatch[] NEW_SUBSTATION_ENERGY_INPUT_HATCH_256A = new MetaTileEntitySubstationEnergyHatch[4];
 
     public static MetaTileEntityPrimitiveMudPump PRIMITIVE_MUD_PUMP;

--- a/src/main/java/supersymmetry/common/metatileentities/multiblockpart/SusyMetaTileEntitySubstationEnergyHatch.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multiblockpart/SusyMetaTileEntitySubstationEnergyHatch.java
@@ -1,0 +1,37 @@
+package supersymmetry.common.metatileentities.multiblockpart;
+
+import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityEnergyHatch;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntitySubstationEnergyHatch;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import supersymmetry.common.metatileentities.SuSyMetaTileEntities;
+
+public class SusyMetaTileEntitySubstationEnergyHatch extends MetaTileEntitySubstationEnergyHatch
+                                           implements IMultiblockAbilityPart<IEnergyContainer> {
+
+    public SusyMetaTileEntitySubstationEnergyHatch(ResourceLocation metaTileEntityId, int tier, int amperage,
+                                                   boolean isExportHatch) {
+        super(metaTileEntityId, tier, amperage, isExportHatch);
+    }
+
+    @Override
+    public void getSubItems(CreativeTabs creativeTab, NonNullList<ItemStack> subItems) {
+        for (MetaTileEntityEnergyHatch hatch : SuSyMetaTileEntities.NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_64A) {
+            if (hatch != null) subItems.add(hatch.getStackForm());
+        }
+        for (MetaTileEntityEnergyHatch hatch : SuSyMetaTileEntities.NEW_SUBSTATION_ENERGY_OUTPUT_HATCH_256A) {
+            if (hatch != null) subItems.add(hatch.getStackForm());
+        }
+        for (MetaTileEntityEnergyHatch hatch : SuSyMetaTileEntities.NEW_SUBSTATION_ENERGY_INPUT_HATCH_64A) {
+            if (hatch != null) subItems.add(hatch.getStackForm());
+        }
+        for (MetaTileEntityEnergyHatch hatch : SuSyMetaTileEntities.NEW_SUBSTATION_ENERGY_INPUT_HATCH_256A) {
+            if (hatch != null) subItems.add(hatch.getStackForm());
+        }
+    }
+
+}

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -1100,6 +1100,13 @@ susy.machine.energy_hatch.output_4a.hv.name=HV 4A Dynamo Hatch
 susy.machine.energy_hatch.output_16a.hv.name=HV 16A Dynamo Hatch
 susy.machine.energy_hatch.output_16a.ev.name=EV 16A Dynamo Hatch
 
+susy.machine.substation_energy_hatch.input_64a.ev.name=EV 64A Substation Energy Hatch
+
+susy.machine.substation_energy_hatch.output_64a.lv.name=LV 64A Substation Dynamo Hatch
+susy.machine.substation_energy_hatch.output_64a.mv.name=MV 64A Substation Dynamo Hatch
+susy.machine.substation_energy_hatch.output_64a.hv.name=HV 64A Substation Dynamo Hatch
+susy.machine.substation_energy_hatch.output_64a.ev.name=EV 64A Substation Dynamo Hatch
+
 # Quadruple & Nonuple Fluid Hatches
 
 gregtech.machine.fluid_hatch.import_4x.lv.name=LV Quadruple Input Hatch


### PR DESCRIPTION
Adds LV-EV 64A Substation Dynamo Hatches and a 64A EV Substation Energy Hatch.
The amounts of energy used in SuSy are much higher than vanilla GregTech, so better hatches are needed as well.