### PR TITLE
Add decorative sintering blocks with permanent bloom effect

### DIFF
--- a/src/main/java/supersymmetry/common/blocks/BlockSinteringBrick.java
+++ b/src/main/java/supersymmetry/common/blocks/BlockSinteringBrick.java
@@ -40,9 +40,8 @@ public class BlockSinteringBrick extends VariantActiveBlock<BlockSinteringBrick.
 
         BRICK("sintering_block_brick", false),
         MAGNETOPLATED("sintering_block_magnetoplated", true),
-        BRICK_BLOOM("sintering_block_brick_bloom_deco", false)
-        MAGNETOPLATED_BLOOM("sintering_block_magnetoplated_bloom_deco", false);
-        
+        BRICK_BLOOM("sintering_block_brick_bloom_deco", false),
+        MAGNETOPLATED_BLOOM("sintering_block_magnetoplated_bloom_deco", true);
 
         public final String name;
         public final boolean canResistPlasma;

--- a/src/main/java/supersymmetry/common/blocks/BlockSinteringBrick.java
+++ b/src/main/java/supersymmetry/common/blocks/BlockSinteringBrick.java
@@ -39,7 +39,10 @@ public class BlockSinteringBrick extends VariantActiveBlock<BlockSinteringBrick.
     public enum SinteringBrickType implements IStringSerializable {
 
         BRICK("sintering_block_brick", false),
-        MAGNETOPLATED("sintering_block_magnetoplated", true);
+        MAGNETOPLATED("sintering_block_magnetoplated", true),
+        BRICK_BLOOM("sintering_block_brick_bloom_deco", false)
+        MAGNETOPLATED_BLOOM("sintering_block_magnetoplated_bloom_deco", false);
+        
 
         public final String name;
         public final boolean canResistPlasma;

--- a/src/main/resources/assets/susy/blockstates/sintering_brick.json
+++ b/src/main/resources/assets/susy/blockstates/sintering_brick.json
@@ -27,14 +27,28 @@
         "top_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic_bloom"
       }
     },
-    "variant=sintering_block_brick_bloom_deco" : {
+    "active=false,variant=sintering_block_brick_bloom_deco" : {
       "model" : "gregtech:cube_2_layer_all",
       "textures" : {
         "bot_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks",
         "top_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_bloom"
       }
     },
-    "variant=sintering_block_magnetoplated_bloom_deco" : {
+    "active=false,variant=sintering_block_magnetoplated_bloom_deco" : {
+      "model" : "gregtech:cube_2_layer_all",
+      "textures" : {
+        "bot_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic",
+        "top_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic_bloom"
+      }
+    },
+    "active=true,variant=sintering_block_brick_bloom_deco" : {
+      "model" : "gregtech:cube_2_layer_all",
+      "textures" : {
+        "bot_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks",
+        "top_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_bloom"
+      }
+    },
+    "active=true,variant=sintering_block_magnetoplated_bloom_deco" : {
       "model" : "gregtech:cube_2_layer_all",
       "textures" : {
         "bot_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic",

--- a/src/main/resources/assets/susy/blockstates/sintering_brick.json
+++ b/src/main/resources/assets/susy/blockstates/sintering_brick.json
@@ -26,6 +26,20 @@
         "bot_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic",
         "top_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic_bloom"
       }
+    },
+    "variant=sintering_block_brick_bloom_deco" : {
+      "model" : "gregtech:cube_2_layer_all",
+      "textures" : {
+        "bot_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks",
+        "top_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_bloom"
+      }
+    },
+    "variant=sintering_block_magnetoplated_bloom_deco" : {
+      "model" : "gregtech:cube_2_layer_all",
+      "textures" : {
+        "bot_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic",
+        "top_all" : "gregtech:blocks/casings/sintering_bricks/sintering_bricks_magnetic_bloom"
+      }
     }
   }
 }

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -7,9 +7,9 @@ tile.wire_coil.tooltip_evaporation=§8Evaporation Pool
 tile.wire_coil.tooltip_energy_evaporating=  §cHeat Generation: §f%,d kJ/t
 
 tile.sintering_brick.sintering_block_brick.name=Brick Sintering Block
-tile.sintering_brick.sintering_block_brick_bloom_deco.name=Brick Sintering Block Blooming
+tile.sintering_brick.sintering_block_brick_bloom_deco.name=Active Brick Sintering Block
 tile.sintering_brick.sintering_block_magnetoplated.name=Magnetoplated Sintering Block
-tile.sintering_brick.sintering_block_magnetoplated_bloom_deco.name=Magnetoplated Sintering Block Blooming
+tile.sintering_brick.sintering_block_magnetoplated_bloom_deco.name=Active Magnetoplated Sintering Block
 
 
 tile.coagulation_tank_wall.wooden_coagulation_tank_wall.name=Wooden Coagulation Tank Wall

--- a/src/main/resources/assets/susy/lang/en_us.lang
+++ b/src/main/resources/assets/susy/lang/en_us.lang
@@ -7,7 +7,10 @@ tile.wire_coil.tooltip_evaporation=§8Evaporation Pool
 tile.wire_coil.tooltip_energy_evaporating=  §cHeat Generation: §f%,d kJ/t
 
 tile.sintering_brick.sintering_block_brick.name=Brick Sintering Block
+tile.sintering_brick.sintering_block_brick_bloom_deco.name=Brick Sintering Block Blooming
 tile.sintering_brick.sintering_block_magnetoplated.name=Magnetoplated Sintering Block
+tile.sintering_brick.sintering_block_magnetoplated_bloom_deco.name=Magnetoplated Sintering Block Blooming
+
 
 tile.coagulation_tank_wall.wooden_coagulation_tank_wall.name=Wooden Coagulation Tank Wall
 tile.separator_rotor.steel.name=Steel Gravity Separator Rotor


### PR DESCRIPTION
Two new variants are added to have the bloom effect permanently, to later be crafted using the chisel or specific crafting recipes (it needs to be configured with Groovy), which would be another PR soon.