### PR TITLE
Fix: Natural Draft Cooling Tower should allow placement of input bus for circuit

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityNaturalDraftCoolingTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityNaturalDraftCoolingTower.java
@@ -169,7 +169,7 @@ public class MetaTileEntityNaturalDraftCoolingTower extends CachedPatternRecipeM
                         "               ", "               ", "               ", "               ", "               ",
                         "               ")
                 .where('S', selfPredicate())
-                .where('O', states(getCasingState()).or(autoAbilities(true, true, false, false, false, true, false)))
+                .where('O', states(getCasingState()).or(autoAbilities(true, true, true, false, false, true, false)))
                 .where('I',
                         states(MetaBlocks.STONE_BLOCKS.get(StoneVariantBlock.StoneVariant.SMOOTH)
                                 .getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT))


### PR DESCRIPTION
Fixes: https://github.com/SymmetricDevs/Susy-Core/issues/666

This multi requires the circuit to function as the recipes all require a circuit.

Tested by building susycore locally with gradle, then substituting my local susy instance with the built susycore jar.

NEI showing valid position for input bus:

<img width="868" height="604" alt="image" src="https://github.com/user-attachments/assets/9d7a6fae-2533-4838-9ca1-8fe56c8c8a73" />
