### PR TITLE
Remove undeserving perfect overclocks

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityAdvancedArcFurnace.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityAdvancedArcFurnace.java
@@ -33,7 +33,7 @@ public class MetaTileEntityAdvancedArcFurnace extends RecipeMapMultiblockControl
 
     public MetaTileEntityAdvancedArcFurnace(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, SuSyRecipeMaps.ADVANCED_ARC_FURNACE);
-        this.recipeMapWorkable = new MultiblockRecipeLogic(this, true);
+        this.recipeMapWorkable = new MultiblockRecipeLogic(this, false);
     }
 
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPolymerizationTank.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityPolymerizationTank.java
@@ -33,7 +33,7 @@ public class MetaTileEntityPolymerizationTank extends RecipeMapMultiblockControl
 
     public MetaTileEntityPolymerizationTank(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, SuSyRecipeMaps.POLYMERIZATION_RECIPES);
-        this.recipeMapWorkable = new MultiblockRecipeLogic(this, true);
+        this.recipeMapWorkable = new MultiblockRecipeLogic(this, false);
     }
 
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {

--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityVacuumDistillationTower.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityVacuumDistillationTower.java
@@ -38,7 +38,7 @@ import supersymmetry.client.renderer.textures.SusyTextures;
 public class MetaTileEntityVacuumDistillationTower extends MetaTileEntityOrderedDT {
 
     public MetaTileEntityVacuumDistillationTower(ResourceLocation metaTileEntityId) {
-        super(metaTileEntityId, SuSyRecipeMaps.VACUUM_DISTILLATION_RECIPES, true);
+        super(metaTileEntityId, SuSyRecipeMaps.VACUUM_DISTILLATION_RECIPES, false);
     }
 
     @Override


### PR DESCRIPTION
Some multiblocks arent deserving of the coveted perfect overclock.
IMO these should be saved until later tiers to prevent stagnation.
* Vacuum Distillation Tower
* Industrial Arc Furnace
* Polymerization Tank