### PR TITLE
Allow Hot Isostatic Press to use distinct buses

### DIFF
--- a/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHotIsostaticPress.java
+++ b/src/main/java/supersymmetry/common/metatileentities/multi/electric/MetaTileEntityHotIsostaticPress.java
@@ -100,4 +100,9 @@ public class MetaTileEntityHotIsostaticPress extends RecipeMapMultiblockControll
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity iGregTechTileEntity) {
         return new MetaTileEntityHotIsostaticPress(metaTileEntityId);
     }
+
+    @Override
+    public boolean canBeDistinct() {
+        return true;
+    }
 }


### PR DESCRIPTION
Figure this could be useful considering there's a bunch of different molds that can be used.